### PR TITLE
Add a Coq plugin repo

### DIFF
--- a/plugins/coq
+++ b/plugins/coq
@@ -1,0 +1,1 @@
+repository = https://github.com/gingerhot/asdf-coq.git


### PR DESCRIPTION
Add a Coq plugin git repo address: https://github.com/gingerhot/asdf-coq