### PR TITLE
Add plugin for golang's dep tool

### DIFF
--- a/plugins/golang-dep
+++ b/plugins/golang-dep
@@ -1,0 +1,1 @@
+repository = https://github.com/mcdan/asdf-golang-dep


### PR DESCRIPTION
Golang's dep is used for dependency management: https://github.com/golang/dep/releases

It has as completely different release cycle than the core tools. This may go away at some point but for that might be a year or more.