### PR TITLE
Add missing java and maven plugins to repository

### DIFF
--- a/plugins/java
+++ b/plugins/java
@@ -1,0 +1,1 @@
+repository = https://github.com/skotchpine/asdf-java.git

--- a/plugins/maven
+++ b/plugins/maven
@@ -1,0 +1,1 @@
+repository = https://github.com/skotchpine/asdf-maven.git


### PR DESCRIPTION
Though they are added in the README (commits 4d44d47 and 031dc6c6) the actual reference to repository is missing for commands `asdf plugin-add java` and `asdf plugin-add maven`.