### PR TITLE
Brand new kops plugin.

### DIFF
--- a/plugins/kops
+++ b/plugins/kops
@@ -1,0 +1,1 @@
+repository = https://github.com/Antiarchitect/asdf-kops.git


### PR DESCRIPTION
kops (https://github.com/kubernetes/kops) helps you create, destroy, upgrade and maintain production-grade, highly available, Kubernetes clusters from the command line.