### PR TITLE
Added Solidity asdf plugin

### DIFF
--- a/plugins/solidity
+++ b/plugins/solidity
@@ -1,0 +1,1 @@
+repository = https://github.com/refillic/asdf-solidity


### PR DESCRIPTION
I have implemented a Solidity plugin for the asdf version manager. It provides the basic `install` and `list-all` implementations. It supports Linux and macOS.