### PR TITLE
fix travis for asdf-python with renamed repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ place for people (and asdf itself) to look for plugins.
 | PHP       | [odarriba/asdf-php](https://github.com/odarriba/asdf-php) | [![Build Status](https://travis-ci.org/odarriba/asdf-php.svg?branch=master)](https://travis-ci.org/odarriba/asdf-php)
 | Postgres  | [smashedtoatoms/asdf-postgres](https://github.com/smashedtoatoms/asdf-postgres) | [![Build Status](https://travis-ci.org/smashedtoatoms/asdf-postgres.svg?branch=master)](https://travis-ci.org/smashedtoatoms/asdf-postgres)
 | protoc    | [paxosglobal/asdf-protoc](https://github.com/paxosglobal/asdf-protoc) | [![Build Status](https://travis-ci.com/paxosglobal/asdf-protoc.svg?branch=master)](https://travis-ci.com/paxosglobal/asdf-protoc)
-| Python    | [tuvistavie/asdf-python](https://github.com/tuvistavie/asdf-python) | [![Build Status](https://travis-ci.org/tuvistavie/asdf-python.svg?branch=master)](https://travis-ci.org/tuvistavie/asdf-python)
+| Python    | [danhper/asdf-python](https://github.com/danhper/asdf-python) | [![Build Status](https://travis-ci.org/danhper/asdf-python.svg?branch=master)](https://travis-ci.org/danhper/asdf-python)
 | R         | [iroddis/asdf-R](https://github.com/iroddis/asdf-R) | [![Build Status](https://travis-ci.org/iroddis/asdf-R.svg?branch=master)](https://travis-ci.org/iroddis/asdf-R)
 | Racket    | [vic/asdf-racket](https://github.com/vic/asdf-racket) | [![Build Status](https://travis-ci.org/vic/asdf-racket.svg?branch=master)](https://travis-ci.org/vic/asdf-racket)
 | Rebar     | [Stratus3D/asdf-rebar](https://github.com/Stratus3D/asdf-rebar) | [![Build Status](https://travis-ci.org/Stratus3D/asdf-rebar.svg?branch=master)](https://travis-ci.org/Stratus3D/asdf-rebar)

--- a/plugins/python
+++ b/plugins/python
@@ -1,1 +1,1 @@
-repository = https://github.com/tuvistavie/asdf-python
+repository = https://github.com/danhper/asdf-python


### PR DESCRIPTION
https://github.com/tuvistavie/asdf-python -> https://github.com/danhper/asdf-python

analogous to https://github.com/danhper/asdf-python/pull/46