### PR TITLE
Update java plugin

### DIFF
--- a/plugins/java
+++ b/plugins/java
@@ -1,1 +1,1 @@
-repository = https://github.com/skotchpine/asdf-java.git
+repository = https://github.com/halcyon/asdf-java.git


### PR DESCRIPTION
The [skotchpine java plugin](https://github.com/skotchpine/asdf-java) has not been updated since late 2018. Since then several of the Oracle JDKs can no longer be installed as Oracle requires a login for anything higher than oracle-8.141. I've incorporated changes from the openjdk/zulu related PRs that have been awaiting attention for months in the skotchpine java repo. I've removed the Oracle JDKs that can no longer be installed and replaced/augmented them with [Azul's Zulu builds](https://www.azul.com/downloads/zulu/). If @skotchpine would prefer me create a PR for their plugin, I would be glad to do so - but in light of their current backlog of PRs, it appears that they might prefer to pass the torch to a new maintainer.