### PR TITLE
✨ Add plugin for Yarn

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,4 +115,5 @@ place for people (and asdf itself) to look for plugins.
 | Terragrunt | [td7x/asdf/terragrunt/](https://gitlab.com/td7x/asdf/terragrunt/) | [![pipeline status](https://gitlab.com/td7x/asdf/terragrunt/badges/master/pipeline.svg)](https://gitlab.com/td7x/asdf/terragrunt/commits/master)
 | TFLint | [RykHawthorn/asdf-tflint](https://github.com/RykHawthorn/asdf-tflint) | [![Build Status](https://travis-ci.org/RykHawthorn/asdf-tflint.svg?branch=master)](https://travis-ci.org/RykHawthorn/asdf-tflint)
 | Vault     | [Banno/asdf-hashicorp](https://github.com/Banno/asdf-hashicorp) | [![Build Status](https://travis-ci.org/Banno/asdf-hashicorp.svg?branch=master)](https://travis-ci.org/Banno/asdf-hashicorp)
+| Yarn      | [twuni/asdf-yarn](https://github.com/twuni/asdf-yarn) | [![Build Status](https://travis-ci.org/twuni/asdf-yarn.svg?branch=master)](https://travis-ci.org/twuni/asdf-yarn)
 | .Net Core | [emersonsoares/asdf-dotnet-core](https://github.com/emersonsoares/asdf-dotnet-core) | [![Build Status](https://travis-ci.org/emersonsoares/asdf-dotnet-core.svg?branch=master)](https://travis-ci.org/emersonsoares/asdf-dotnet-core)

--- a/plugins/yarn
+++ b/plugins/yarn
@@ -1,0 +1,1 @@
+repository = https://github.com/twuni/asdf-yarn.git


### PR DESCRIPTION
This PR introduces an asdf plugin for [Yarn](https://yarnpkg.com/en/), a popular alternative to NPM for JavaScript libraries and applications. This plugin has been a missing piece for me for some time now, so I figured it's long overdue to join the asdf plugin ecosystem.

Source: https://github.com/twuni/asdf-yarn
