### PR TITLE
Enhance test.sh to better detect success/fail.

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -1,18 +1,12 @@
 #!/usr/bin/env bash
 
 fails=0
-skips=0
 total=0
 while read -r -a plugin; do
   total=$((total+1))
   travis_web_url="https://${plugin[0]}/${plugin[1]}"
-  if [[ ${plugin[0]} =~ .com ]]; then
-    skips=$((skips+1))
-    echo "Plugin build check skipped: ${travis_web_url} -- travis-ci.com (enterprise) checks are unsupported"
-    continue
-  fi
   url="https://api.${plugin[0]}/repos/${plugin[1]}/branches/${plugin[2]}"
-  curl -sq ${url} | grep '"state":"passed"' &> /dev/null
+  curl -sq -H 'Accept: application/vnd.travis-ci.2.1+json' ${url} | grep '"state":"passed"' &> /dev/null
   status=$?
   if [[ ${status} != 0 ]]; then
     fails=$((fails+1))
@@ -23,7 +17,6 @@ done < <(grep -o 'travis.*\.svg[^)]*' README.md | sed "s~https?://~~; s:/: :; s/
 echo
 echo "Plugins available: ${total}"
 echo "Plugin build checks passed: $((total-fails))"
-echo "Plugin build checks skipped: ${skips}"
 echo "Plugin build checks failed: ${fails}"
 
 exit ${fails}

--- a/test.sh
+++ b/test.sh
@@ -6,9 +6,7 @@ while read -r -a plugin; do
   total=$((total+1))
   travis_web_url="https://${plugin[0]}/${plugin[1]}"
   url="https://api.${plugin[0]}/repos/${plugin[1]}/branches/${plugin[2]}"
-  curl -sq -H 'Accept: application/vnd.travis-ci.2.1+json' ${url} | grep '"state":"passed"' &> /dev/null
-  status=$?
-  if [[ ${status} != 0 ]]; then
+  if ! curl -sq -H 'Accept: application/vnd.travis-ci.2.1+json' ${url} | grep -q '"state":"passed"'; then
     fails=$((fails+1))
     echo "Plugin build check failed:  ${travis_web_url}"
   fi


### PR DESCRIPTION
* Add ability to skip tests for travis-ci.com (enterprise).
* Print a summary upon completion showing numbers of plugins,
  number skipped, and number failed.

Helps with #84 and #85.

After poking around a bit I see that all of the Travis Enterprise checks are detected as failing. Also, some of the checks in this script were failing while the real build was successful because the success/fail check was only looking at the most recent build instead of the build on the target branch.

test.sh now _skips_ enterprise links and should detect the rest of the success/fail correctly.

Script output looks like the following now:
```
Plugin build check failed:  https://travis-ci.org/marciogm/asdf-crystal
Plugin build check failed:  https://travis-ci.org/mikestephens/asdf-elasticsearch
Plugin build check failed:  https://travis-ci.org/vic/asdf-elm
Plugin build check failed:  https://travis-ci.org/vic/asdf-haskell
Plugin build check failed:  https://travis-ci.org/halcyon/asdf-java
Plugin build check failed:  https://travis-ci.org/rkyleg/asdf-julia
Plugin build check failed:  https://travis-ci.org/skotchpine/asdf-maven
Plugin build check failed:  https://travis-ci.org/sylph01/asdf-mongodb
Plugin build check failed:  https://travis-ci.org/vic/asdf-ocaml
Plugin build check failed:  https://travis-ci.org/odarriba/asdf-php
Plugin build check failed:  https://travis-ci.org/smashedtoatoms/asdf-redis
Plugin build check failed:  https://travis-ci.org/code-lever/asdf-rust
Plugin build check failed:  https://travis-ci.org/mtatheonly/asdf-scala
Plugin build check failed:  https://travis-ci.org/RykHawthorn/asdf-tflint

Plugins available: 88
Plugin build checks passed: 74
Plugin build checks failed: 14
```