### PR TITLE
add V (The V Programming Language) plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ place for people (and asdf itself) to look for plugins.
 | Terragrunt | [td7x/asdf/terragrunt/](https://gitlab.com/td7x/asdf/terragrunt/) | [![pipeline status](https://gitlab.com/td7x/asdf/terragrunt/badges/master/pipeline.svg)](https://gitlab.com/td7x/asdf/terragrunt/commits/master)
 | TFLint | [RykHawthorn/asdf-tflint](https://github.com/RykHawthorn/asdf-tflint) | [![Build Status](https://travis-ci.org/RykHawthorn/asdf-tflint.svg?branch=master)](https://travis-ci.org/RykHawthorn/asdf-tflint)
 | Tmux      | [aphecetche/asdf-tmux](https://github.com/aphecetche/asdf-tmux) | [![Build Status](https://travis-ci.org/aphecetche/asdf-tmux.svg?branch=master)](https://travis-ci.org/aphecetche/asdf-tmux)
+| V         | [ndac-todoroki/asdf-v](https://github.com/ndac-todoroki/asdf-v) | [![Build Status](https://travis-ci.org/ndac-todoroki/asdf-v.svg?branch=master)](https://travis-ci.org/ndac-todoroki/asdf-v)
 | Vault     | [Banno/asdf-hashicorp](https://github.com/Banno/asdf-hashicorp) | [![Build Status](https://travis-ci.org/Banno/asdf-hashicorp.svg?branch=master)](https://travis-ci.org/Banno/asdf-hashicorp)
 | Yarn      | [twuni/asdf-yarn](https://github.com/twuni/asdf-yarn) | [![Build Status](https://travis-ci.org/twuni/asdf-yarn.svg?branch=master)](https://travis-ci.org/twuni/asdf-yarn)
 | .Net Core | [emersonsoares/asdf-dotnet-core](https://github.com/emersonsoares/asdf-dotnet-core) | [![Build Status](https://travis-ci.org/emersonsoares/asdf-dotnet-core.svg?branch=master)](https://travis-ci.org/emersonsoares/asdf-dotnet-core)

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ place for people (and asdf itself) to look for plugins.
 | Terragrunt | [td7x/asdf/terragrunt/](https://gitlab.com/td7x/asdf/terragrunt/) | [![pipeline status](https://gitlab.com/td7x/asdf/terragrunt/badges/master/pipeline.svg)](https://gitlab.com/td7x/asdf/terragrunt/commits/master)
 | TFLint | [RykHawthorn/asdf-tflint](https://github.com/RykHawthorn/asdf-tflint) | [![Build Status](https://travis-ci.org/RykHawthorn/asdf-tflint.svg?branch=master)](https://travis-ci.org/RykHawthorn/asdf-tflint)
 | Tmux      | [aphecetche/asdf-tmux](https://github.com/aphecetche/asdf-tmux) | [![Build Status](https://travis-ci.org/aphecetche/asdf-tmux.svg?branch=master)](https://travis-ci.org/aphecetche/asdf-tmux)
-| V         | [ndac-todoroki/asdf-v](https://github.com/ndac-todoroki/asdf-v) | [![Build Status](https://travis-ci.org/ndac-todoroki/asdf-v.svg?branch=master)](https://travis-ci.org/ndac-todoroki/asdf-v)
+| V         | [ndac-todoroki/asdf-v](https://github.com/ndac-todoroki/asdf-v) | [![Build Status](https://travis-ci.com/ndac-todoroki/asdf-v.svg?branch=master)](https://travis-ci.com/ndac-todoroki/asdf-v)
 | Vault     | [Banno/asdf-hashicorp](https://github.com/Banno/asdf-hashicorp) | [![Build Status](https://travis-ci.org/Banno/asdf-hashicorp.svg?branch=master)](https://travis-ci.org/Banno/asdf-hashicorp)
 | Yarn      | [twuni/asdf-yarn](https://github.com/twuni/asdf-yarn) | [![Build Status](https://travis-ci.org/twuni/asdf-yarn.svg?branch=master)](https://travis-ci.org/twuni/asdf-yarn)
 | .Net Core | [emersonsoares/asdf-dotnet-core](https://github.com/emersonsoares/asdf-dotnet-core) | [![Build Status](https://travis-ci.org/emersonsoares/asdf-dotnet-core.svg?branch=master)](https://travis-ci.org/emersonsoares/asdf-dotnet-core)

--- a/plugins/v
+++ b/plugins/v
@@ -1,0 +1,1 @@
+repository = https://github.com/ndac-todoroki/asdf-v.git


### PR DESCRIPTION
### Note;

`asdf-v` uses symlinks to enable asdf versioning.
Currently the path is hardcode-limited to `~/code/v`, so `asdf-v` deletes and create the symlink there. If the user has a predefined `~/code/v`, it may be an issue.
This limitation is planned to be gone, when V enables flexible installation paths.