### PR TITLE
fix: prepend FAIL to any failures in test_plugin.sh

### DIFF
--- a/test_plugin.sh
+++ b/test_plugin.sh
@@ -3,7 +3,7 @@
 # See: ./test_plugin.sh --help
 
 function fail() {
-  echo "$*" >&2
+  echo "FAIL: $*" >&2
   exit 1
 }
 


### PR DESCRIPTION
As cited in #428, I misinterpreted the output of `test_plugin.sh` partly because the output looked like pretty standard output. This change adds "FAIL:" to any output that is considered a failure to make the failures more apparent. 

Thank you for contributing to asdf-plugins!
