### PR TITLE
docs: clean up Travis refs

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,4 +1,4 @@
-name: Main workflow
+name: Lint
 
 on:
   pull_request:
@@ -19,11 +19,8 @@ jobs:
         with:
           node-version: 14.x
 
-      - name: Install Prettier
-        run: npm install --global prettier
-
       - name: Check formatting
-        run: prettier --check README.md
+        run: npx prettier --check README.md
 
       - name: Check new plugin is registered correctly
-        run: bash test_plugin.sh --diff origin/master ${{ github.sha }}
+        run: bash test_plugin.sh --diff ${{ github.base_ref }} ${{ github.sha }}

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -23,4 +23,4 @@ jobs:
         run: npx prettier --check README.md
 
       - name: Check new plugin is registered correctly
-        run: bash test_plugin.sh --diff ${{ github.base_ref }} ${{ github.sha }}
+        run: bash test_plugin.sh --diff origin/master ${{ github.sha }}

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ asdf plugin add <name> <git_url>
 
 ## Existing Plugins
 
-Plugins listed here should be *stable* and actively *maintained*. If you have issues with a specific plugin please raise them on the plugin repository first. If a deprecated plugin is listed here, please let us know and create a PR to add the most used alternative.
+Plugins listed here should be _stable_ and actively _maintained_. If you have issues with a specific plugin please raise them on the plugin repository first. If a deprecated plugin is listed here, please let us know and create a PR to add the most used alternative.
 
 ## Creating a new Plugin
 

--- a/README.md
+++ b/README.md
@@ -1,31 +1,31 @@
 # asdf plugins repository
 
-This is the [asdf](https://github.com/asdf-vm/asdf) plugins repository; its
-purpose is to serve a list of community maintained _stable_ plugins.
+The purpose of the [asdf](https://github.com/asdf-vm/asdf) plugins repository is to enable shorthand installation of plugins with:
 
-Maintaining this list is just a convenience for helping new asdf users so that
-listed plugins can be installed by just `asdf plugin-add NAME` without having to
-lookup for the actual plugin repo.
+```shell
+asdf plugin add <name>
+```
 
-Thus, this list should be updated when a plugin is broken or when someone has
-forked a better version. Just remember that you can actually use any repo with
-asdf, and this list is just for having a central place for people (and asdf
-itself) to look for plugins.
+It is important to know that you can install plugins without them being in this repo with:
+
+```shell
+asdf plugin add <name> <git_url>
+```
+
+## Existing Plugins
+
+Plugins listed here should be *stable* and actively *maintained*. If you have issues with a specific plugin please raise them on the plugin repository first. If a deprecated plugin is listed here, please let us know and create a PR to add the most used alternative.
+
+## Creating a new Plugin
+
+- Read the [creating plugins guide](https://github.com/asdf-vm/asdf/blob/master/docs/plugins-create.md)
+- Consider using our [Template](https://github.com/asdf-vm/asdf-plugin-template) which has the core functionality to tools published to GitHub releases and CI for GitHub/GitLab/CircleCI out of the box.
 
 ## Contributing a new Plugin
 
-- Be sure to read the
-  [creating plugins guide](https://github.com/asdf-vm/asdf/blob/master/docs/plugins-create.md)
-- Test the plugin locally and make sure you can execute the new tool
-  successfully (your shell scripts should work at least on osx and ubuntu linux)
-- Create a travis build for your tool, the build should install and execute your
-  tool with `--version` or similar to test it works.
-- Update the README.md file on this repo to add your new plugin. The list is
-  alphabetically ordered.
-- Create a file in `plugins/` with the same name as your plugin. The contents of
-  the file should be `repository = <your repo>`.
-- Create a pull request showing your plugin's travis build is green. The CI for
-  this repo checks all listed plugin badges are green.
+- Add the plugin to this `README.md`.
+- Create a file with the shortname you wish to be used by asdf in `plugins/<name>`. Then contents should be `repository = <your_repo>`.
+- Create a PR following the instructions in the PR template.
 
 ## Plugin List
 

--- a/plugins/1password-cli
+++ b/plugins/1password-cli
@@ -1,1 +1,1 @@
-repository = https://github.com/NeoHsu/asdf-1password-cli
+repository = https://github.com/NeoHsu/asdf-1password-cli.git

--- a/plugins/1password-cli
+++ b/plugins/1password-cli
@@ -1,1 +1,1 @@
-repository = https://github.com/NeoHsu/asdf-1password-cli.git
+repository = https://github.com/NeoHsu/asdf-1password-cli


### PR DESCRIPTION
## Summary

<!-- short description of your plugin or change here -->

- remove refs to Travis CI script no longer in use noted in #84
- cleans up the documentation to simplify and make it much more clear that `asdf plugin add <name> <git_url>` is an option.
- ~update CI to use `${{ github.base_ref }}` instead of harcoded `origin/master`~
