### PR TITLE
chore: update asdf-r repo

### DIFF
--- a/plugins/R
+++ b/plugins/R
@@ -1,1 +1,1 @@
-repository = https://github.com/taiar/asdf-R.git
+repository = https://github.com/asdf-community/asdf-r.git


### PR DESCRIPTION
I forgot to update this file since the repo migrated to the community.

Probably Github keeps the "redirect" from the repo but it would be good to have this reference updated to the current repository.

## Summary

<!-- short description of your plugin or change here -->


## Checklist

- [x] CI tests are green. If you are using GitHub, you might want to use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions)
- [x] `asdf-plugins` CI sanity checks are green on your PullRequest. Test locally with:

```bash
./test_plugin.sh --file plugins/<PLUGIN_FILE>
```

<!-- Thank you for contributing to asdf-plugins! -->
