### PR TITLE
ci: format readme when updated on main

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,30 @@
+name: Format
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - README.md
+
+jobs:
+  format_readme:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+
+      - name: Format README.md
+        run: npx -y prettier --write README.md
+
+      - name: Commit format of README.md
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: "chore: format README.md"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Lint
+name: Test
 
 on:
   pull_request:
@@ -13,14 +13,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-
-      - name: Use Node.js 14.x
-        uses: actions/setup-node@v1
-        with:
-          node-version: 14.x
-
-      - name: Check formatting
-        run: npx prettier --check README.md
 
       - name: Check new plugin is registered correctly
         run: bash test_plugin.sh --diff origin/master ${{ github.sha }}


### PR DESCRIPTION
## Summary

<!-- short description of your plugin or change here -->

Auto-format `README.md` on merges to main where the `README.md` has changed. Removes `prettier --check` from CI on PRs.

I am very tired of having to correct formatting issues to match `prettier` which no one runs before committing.
