### PR TITLE
Update link to plugin doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Plugins listed here should be _stable_ and actively _maintained_. If you have is
 
 ## Creating a new Plugin
 
-- Read the [creating plugins guide](https://github.com/asdf-vm/asdf/blob/master/docs/plugins-create.md)
+- Read the [creating plugins guide](https://github.com/asdf-vm/asdf/blob/master/docs/plugins/create.md)
 - Consider using our [Template](https://github.com/asdf-vm/asdf-plugin-template) which has the core functionality to tools published to GitHub releases and CI for GitHub/GitLab/CircleCI out of the box.
 
 ### `asdf-community`


### PR DESCRIPTION
## Summary

Just a link update.

## Checklist

- [ ] CI tests are green. If you are using GitHub, you might want to use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions)
- [ ] `asdf-plugins` CI sanity checks are green on your PullRequest. Test locally with:

```bash
./test_plugin.sh --file plugins/<PLUGIN_FILE>
```

<!-- Thank you for contributing to asdf-plugins! -->
