### PR TITLE
move bazel plugin source

### DIFF
--- a/plugins/bazel
+++ b/plugins/bazel
@@ -1,1 +1,1 @@
-repository = https://github.com/rajatvig/asdf-bazel.git
+repository = https://github.com/pjjw/asdf-bazel.git


### PR DESCRIPTION
## Summary

Move the source of the bazel asdf plugin to pjjw/bazel-asdf as current upstream appears unresponsive to pull requests


## Checklist

- [ ] CI tests are green. If you are using GitHub, you might want to use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions)
- [x] `asdf-plugins` CI sanity checks are green on your PullRequest. Test locally with:

```bash
./test_plugin.sh --file plugins/<PLUGIN_FILE>
```

<!-- Thank you for contributing to asdf-plugins! -->
