### PR TITLE
update to more recent repository for scaleway-cli

### DIFF
--- a/plugins/scaleway-cli
+++ b/plugins/scaleway-cli
@@ -1,1 +1,1 @@
-repository = https://github.com/webofmars/asdf-plugin-scaleway-cli.git
+repository = https://github.com/albarralnunez/asdf-plugin-scaleway-cli


### PR DESCRIPTION
current repo is broken, a PR was made, but it also seems unmaintained new proposed repo is the origin of said PR
/cc @albarralnunez

## Summary

<!-- short description of your plugin or change here -->


## Checklist

- [ ] CI tests are green. If you are using GitHub, you might want to use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions)
- [ ] `asdf-plugins` CI sanity checks are green on your PullRequest. Test locally with:

```bash
./test_plugin.sh --file plugins/<PLUGIN_FILE>
```

<!-- Thank you for contributing to asdf-plugins! -->
