### PR TITLE
ci: dependabot for github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,9 @@
----
 version: 2
 updates:
+  # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "monthly"
+    reviewers:
+      - "jthegedus"


### PR DESCRIPTION
## Summary

<!-- short description of your plugin or change here -->

This will use dependabot to check any github action this project uses for updates in order to keep it up-to-date.

https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot


## Checklist

- [x] CI tests are green. If you are using GitHub, you might want to use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions)
- [x] `asdf-plugins` CI sanity checks are green on your PullRequest. Test locally with:

```bash
./test_plugin.sh --file plugins/<PLUGIN_FILE>
```

<!-- Thank you for contributing to asdf-plugins! -->
