### PR TITLE
docs: tell contributors about Conventional Commits in docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,7 @@
    scripts/format.bash
    ```
 1. Create a PR following the instructions in the PR template.
+   1. Make sure you use [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/), both in the commit messages and the pull request title
 
 ## Fixing an existing plugin
 


### PR DESCRIPTION
## Summary

This is not a tool or plugin update, but a minor "fix" regarding what I pointed out [here](https://github.com/asdf-vm/asdf-plugins/pull/847#issuecomment-1607984491).

<!--
## Checklist

- [ ] Format with `scripts/format.bash`
- [ ] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [ ] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_
-->

<!-- Thank you for contributing to asdf-plugins! -->
