### PR TITLE
ci: remove semantic release single-commit rule

### DIFF
--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -14,5 +14,3 @@ jobs:
       - uses: amannn/action-semantic-pull-request@v5.2.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          validateSingleCommit: true


### PR DESCRIPTION
## Summary

As with https://github.com/asdf-vm/asdf/pull/1642

GitHub now supports, and we use, the setting which sets the squash commit message the PR title.

![image](https://github.com/asdf-vm/asdf/assets/20798510/195ea569-368f-4840-b64d-081c2f732f5f)

Since this is now the case, we no longer require single-commit-PRs to have those single commits match the Semantic PR settings.

This will mean the errors from Semantic PR only apply to PR titles and are therefore easier to fix than the single-commit commit message.

## Why

I noticed this **unnecessarily** tripping some people up across the repos. Eg: https://github.com/asdf-vm/asdf-plugins/pull/882