### PR TITLE
feat: add regal plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -588,6 +588,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | redo                          | [chessmango/asdf-redo](https://github.com/chessmango/asdf-redo)                                                 |
 | redskyctl                     | [sudermanjr/asdf-redskyctl](https://github.com/sudermanjr/asdf-redskyctl)                                       |
 | Reg                           | [looztra/asdf-reg](https://github.com/looztra/asdf-reg)                                                         |
+| regal                         | [asdf-community/asdf-regal](https://github.com/asdf-community/asdf-regal)                                       |
 | regctl                        | [ORCID/asdf-regctl](https://github.com/ORCID/asdf-regctl)                                                       |
 | regsync                       | [rsrchboy/asdf-regsync](https://github.com/rsrchboy/asdf-regsync)                                               |
 | restic                        | [xataz/asdf-restic](https://github.com/xataz/asdf-restic)                                                       |

--- a/plugins/regal
+++ b/plugins/regal
@@ -1,0 +1,1 @@
+repository = https://github.com/asdf-community/asdf-regal


### PR DESCRIPTION
## Summary

Description:

- Tool repo URL: https://github.com/StyraInc/regal
- Plugin repo URL: https://github.com/asdf-community/asdf-regal

## Checklist

- [x] Format with `scripts/format.bash`
- [ ] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
