### PR TITLE
fix: do not check CI badges

### DIFF
--- a/scripts/test_plugin.bash
+++ b/scripts/test_plugin.bash
@@ -65,13 +65,6 @@ function check_plugin_from_file() {
   test -n "$README_LINE" ||
     fail "Expected a line at README.md with a link to ${PLUGIN_REPO_NO_GIT}"
 
-  BADGE_COLUMN="$(echo "${README_LINE}" | cut -d '|' -f4)"
-  BADGE_URL="$(echo "${BADGE_COLUMN}" | badge_svg)"
-
-  # Assert that the badge has "pass" text in it, indicating the plugin is healthy
-  curl -qsL "${BADGE_URL}" | grep -o -i 'pass' >/dev/null ||
-    fail "Expected plugin CI badge SVG to be passing but it was not: $BADGE_URL"
-
   echo "OK $PLUGIN_FILE"
 }
 


### PR DESCRIPTION
## Summary

See #943.

This PR removes the check for the CI badges from the `scripts/test_plugin.bash` script, because they have been removed.

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally:
  - [x]  with `scripts/test_plugin.bash --file plugins/elixir`
  - [x]  with `scripts/test_plugin.bash --file plugins/erlang`
  - [x]  ...
- [x] ~Your plugin CI tests are green~

<!-- Thank you for contributing to asdf-plugins! -->
