### PR TITLE
feat: add ksops plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,6 +406,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | krab                          | [ohkrab/asdf-krab](https://github.com/ohkrab/asdf-krab)                                                         |
 | krew                          | [bjw-s/asdf-krew](https://github.com/bjw-s/asdf-krew)                                                           |
 | Ksonnet                       | [Banno/asdf-ksonnet](https://github.com/Banno/asdf-ksonnet)                                                     |
+| ksops                         | [janpieper/asdf-ksops](https://github.com/janpieper/asdf-ksops)                                                 |
 | ktlint                        | [esensar/asdf-ktlint](https://github.com/esensar/asdf-ktlint)                                                   |
 | kube-capacity                 | [looztra/asdf-kube-capacity](https://github.com/looztra/asdf-kube-capacity)                                     |
 | kube-code-generator           | [jimmidyson/asdf-kube-code-generator](https://github.com/jimmidyson/asdf-kube-code-generator)                   |

--- a/plugins/ksops
+++ b/plugins/ksops
@@ -1,0 +1,1 @@
+repository = https://github.com/janpieper/asdf-ksops.git


### PR DESCRIPTION
## Summary

Description:

- Tool repo URL: https://github.com/viaduct-ai/kustomize-sops
- Plugin repo URL: https://github.com/janpieper/asdf-ksops

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/ksops`
- [x] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
