### PR TITLE
fix: swaps deprecated container-structure-test plugin with a function…

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | conftest                      | [looztra/asdf-conftest](https://github.com/looztra/asdf-conftest)                                               |
 | Consul                        | [asdf-community/asdf-hashicorp](https://github.com/asdf-community/asdf-hashicorp)                               |
 | container-diff                | [cgroschupp/asdf-container-diff](https://github.com/cgroschupp/asdf-container-diff)                             |
-| container-structure-test      | [jonathanmorley/asdf-container-structure-test](https://github.com/jonathanmorley/asdf-container-structure-test) |
+| container-structure-test      | [FeryET/asdf-container-structure-test](https://github.com/FeryET/asdf-container-structure-test)                 |
 | cookiecutter                  | [shawon-crosen/asdf-cookiecutter](https://github.com/shawon-crosen/asdf-cookiecutter)                           |
 | Copper                        | [vladlosev/asdf-copper](https://github.com/vladlosev/asdf-copper)                                               |
 | Coq                           | [gingerhot/asdf-coq](https://github.com/gingerhot/asdf-coq)                                                     |

--- a/plugins/container-structure-test
+++ b/plugins/container-structure-test
@@ -1,1 +1,1 @@
-repository = https://github.com/jonathanmorley/asdf-container-structure-test.git
+repository = https://github.com/FeryET/asdf-container-structure-test.git


### PR DESCRIPTION
## Summary

This pull requests removes the old container-structure-test plugin and adds a new plugin that can install the package reliably in various environments.

- Tool repo URL: https://github.com/GoogleContainerTools/container-structure-test
- Plugin repo URL: https://github.com/FeryET/asdf-container-structure-test

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green
- [x] Manual plugin tests using `asdf plugin test` command also succeeded in docker test environments. 
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
