### PR TITLE
fix: Add luaJIT with lowercase name

### DIFF
--- a/plugins/luajit
+++ b/plugins/luajit
@@ -1,0 +1,1 @@
+repository = https://github.com/smashedtoatoms/asdf-luaJIT.git


### PR DESCRIPTION
## Summary

In the same style as 23196487296ba3dea97bf6cc10bf5071081baa21, add entry with lowercase. This is the only other instance of such a case.

- Tool repo URL: N/A
- Plugin repo URL: N/A

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
