### PR TITLE
feat: adds CalendarSync asdf-plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | Bundler                       | [jonathanmorley/asdf-bundler](https://github.com/jonathanmorley/asdf-bundler)                                     |
 | Cabal                         | [sestrella/asdf-ghcup](https://github.com/sestrella/asdf-ghcup)                                                   |
 | Caddy                         | [salasrod/asdf-caddy](https://github.com/salasrod/asdf-caddy)                                                     |
+| CalendarSync                  | [FeryET/asdf-calendarsync](https://github.com/FeryET/asdf-calendarsync)                                           |
 | Calicoctl                     | [FairwindsOps/asdf-calicoctl](https://github.com/FairwindsOps/asdf-calicoctl)                                     |
 | Camunda Modeler               | [barmac/asdf-camunda-modeler](https://github.com/barmac/asdf-camunda-modeler)                                     |
 | cargo-make                    | [kachick/asdf-cargo-make](https://github.com/kachick/asdf-cargo-make)                                             |

--- a/plugins/calendarsync
+++ b/plugins/calendarsync
@@ -1,0 +1,1 @@
+repository = https://github.com/FeryET/asdf-calendarsync.git


### PR DESCRIPTION
## Summary

Description:

- Tool repo URL: https://github.com/inovex/CalendarSync
- Plugin repo URL: https://github.com/FeryET/asdf-calendarsync

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
