### PR TITLE
feat: add libsql-server plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,6 +449,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | Lefthook                      | [jtzero/asdf-lefthook](https://github.com/jtzero/asdf-lefthook)                                                   |
 | Levant                        | [asdf-community/asdf-hashicorp](https://github.com/asdf-community/asdf-hashicorp)                                 |
 | LFE                           | [asdf-community/asdf-lfe](https://github.com/asdf-community/asdf-lfe)                                             |
+| libsql-server                 | [jonasb/asdf-libsql-server](https://github.com/jonasb/asdf-libsql-server)                                         |
 | Lima                          | [CrouchingMuppet/asdf-lima](https://github.com/CrouchingMuppet/asdf-lima)                                         |
 | Link (system tools)           | [asdf-community/asdf-link](https://github.com/asdf-community/asdf-link)                                           |
 | Linkerd                       | [kforsthoevel/asdf-linkerd](https://github.com/kforsthoevel/asdf-linkerd)                                         |

--- a/plugins/libsql-server
+++ b/plugins/libsql-server
@@ -1,0 +1,1 @@
+repository = https://github.com/jonasb/asdf-libsql-server.git


### PR DESCRIPTION
## Summary

Description:

- Tool repo URL: https://github.com/tursodatabase/libsql/tree/main/libsql-server
- Plugin repo URL: https://github.com/jonasb/asdf-libsql-server

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
