### PR TITLE
feat: add new k3s plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,6 +381,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | k0sctl                        | [Its-Alex/asdf-plugin-k0sctl](https://github.com/Its-Alex/asdf-plugin-k0sctl)                                     |
 | k2tf                          | [carlduevel/asdf-k2tf](https://github.com/carlduevel/asdf-k2tf)                                                   |
 | k3d                           | [spencergilbert/asdf-k3d](https://github.com/spencergilbert/asdf-k3d)                                             |
+| k3s                           | [dmpe/asdf-k3s](https://github.com/dmpe/asdf-k3s)                                                                 |
 | k3sup                         | [cgroschupp/asdf-k3sup](https://github.com/cgroschupp/asdf-k3sup)                                                 |
 | k6                            | [grimoh/asdf-k6](https://github.com/grimoh/asdf-k6)                                                               |
 | k9s                           | [looztra/asdf-k9s](https://github.com/looztra/asdf-k9s)                                                           |

--- a/plugins/k3s
+++ b/plugins/k3s
@@ -1,0 +1,1 @@
+repository = https://github.com/dmpe/asdf-k3s.git


### PR DESCRIPTION
## Summary

Add new plugin for k3s binary.

Description:

- Tool repo URL: https://github.com/k3s-io/k3s
- Plugin repo URL: https://github.com/dmpe/asdf-k3s

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_
  - only for linux, mac14 github action runner did not worked (the project does not seem to support mac m1+)

<!-- Thank you for contributing to asdf-plugins! -->
