### PR TITLE
feat: add hishtory plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | Helmsman                      | [luisdavim/asdf-helmsman](https://github.com/luisdavim/asdf-helmsman)                                             |
 | heroku-cli                    | [treilly94/asdf-heroku-cli](https://github.com/treilly94/asdf-heroku-cli)                                         |
 | hey                           | [raimon49/asdf-hey](https://github.com/raimon49/asdf-hey)                                                         |
+| hishtory                      | [asdf-community/asdf-hishtory](https://github.com/asdf-community/asdf-hishtory)                                   |
 | hledger                       | [airtonix/hledger](https://github.com/airtonix/asdf-hledger)                                                      |
 | hledger-flow                  | [airtonix/hledger-flow](https://github.com/airtonix/asdf-hledger-flow)                                            |
 | hostctl                       | [svenluijten/asdf-hostctl](https://github.com/svenluijten/asdf-hostctl)                                           |

--- a/plugins/hishtory
+++ b/plugins/hishtory
@@ -1,0 +1,1 @@
+repository = https://github.com/asdf-community/asdf-hishtory.git


### PR DESCRIPTION
## Summary

Description:

- Tool repo URL: https://github.com/ddworken/hishtory
- Plugin repo URL: https://github.com/asdf-community/asdf-hishtory

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
