### PR TITLE
feat: add cljstyle plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | cilium-hubble                 | [NitriKx/asdf-cilium-hubble](https://github.com/NitriKx/asdf-cilium-hubble)                                       |
 | Clarinet                      | [alexgo-io/asdf-clarinet](https://github.com/alexgo-io/asdf-clarinet)                                             |
 | clj-kondo                     | [rynkowsg/asdf-clj-kondo](https://github.com/rynkowsg/asdf-clj-kondo)                                             |
+| cljstyle                      | [abogoyavlensky/asdf-cljstyle](https://github.com/abogoyavlensky/asdf-cljstyle)                                   |
 | Clojure                       | [asdf-community/asdf-clojure](https://github.com/asdf-community/asdf-clojure)                                     |
 | Cloudflared                   | [threkk/asdf-cloudflared](https://github.com/threkk/asdf-cloudflared)                                             |
 | cloud-sql-proxy               | [pbr0ck3r/asdf-cloud-sql-proxy](https://github.com/pbr0ck3r/asdf-cloud-sql-proxy)                                 |

--- a/plugins/cljstyle
+++ b/plugins/cljstyle
@@ -1,0 +1,1 @@
+repository = https://github.com/abogoyavlensky/asdf-cljstyle.git


### PR DESCRIPTION
## Summary

Description: cljstyle plugin, a tool for formatting Clojure code

- Tool repo URL: https://github.com/greglook/cljstyle
- Plugin repo URL: https://github.com/abogoyavlensky/asdf-cljstyle

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
