### PR TITLE
feat: Add bazelisk plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | Batect                        | [johnlayton/asdf-batect](https://github.com/johnlayton/asdf-batect)                                               |
 | Bats (Bash unittest)          | [timgluz/asdf-bats](https://github.com/timgluz/asdf-bats)                                                         |
 | Bazel                         | [rajatvig/asdf-bazel](https://github.com/rajatvig/asdf-bazel)                                                     |
+| bazelisk                      | [josephtate/asdf-bazelisk](https://github.com/josephtate/asdf-bazelisk)                                           |
 | bbr                           | [vmware-tanzu/tanzu-plug-in-for-asdf](https://github.com/vmware-tanzu/tanzu-plug-in-for-asdf)                     |
 | bbr-s3-config-validator       | [vmware-tanzu/tanzu-plug-in-for-asdf](https://github.com/vmware-tanzu/tanzu-plug-in-for-asdf)                     |
 | benthos                       | [benthosdev/benthos-asdf](https://github.com/benthosdev/benthos-asdf)                                             |

--- a/plugins/bazelisk
+++ b/plugins/bazelisk
@@ -1,0 +1,1 @@
+repository = https://github.com/josephtate/asdf-bazelisk.git


### PR DESCRIPTION
## Summary

Description: Add bazelisk plugin. Bazelisk is a version manager for the bazel build tool.

- Tool repo URL: https://github.com/bazelbuild/bazelisk
- Plugin repo URL: https://github.com/josephtate/asdf-bazelisk

## Checklist

- [X ] Format with `scripts/format.bash`
- [X ] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [X ] Your plugin CI tests are green
