### PR TITLE
feat: add stratus-red-team plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -662,6 +662,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | Steel Bank Common Lisp (sbcl) | [smashedtoatoms/asdf-sbcl](https://github.com/smashedtoatoms/asdf-sbcl)                                           |
 | step                          | [log2/asdf-step](https://github.com/log2/asdf-step)                                                               |
 | Stern                         | [looztra/asdf-stern](https://github.com/looztra/asdf-stern)                                                       |
+| stratus-red-team              | [vthiery/asdf-stratus-red-team](https://github.com/vthiery/asdf-stratus-red-team)                                 |
 | stripe-cli                    | [offbyone/asdf-stripe](https://github.com/offbyone/asdf-stripe)                                                   |
 | stylua                        | [jc00ke/asdf-stylua](https://github.com/jc00ke/asdf-stylua)                                                       |
 | svu                           | [asdf-community/asdf-svu](https://github.com/asdf-community/asdf-svu)                                             |

--- a/README.md
+++ b/README.md
@@ -662,7 +662,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | Steel Bank Common Lisp (sbcl) | [smashedtoatoms/asdf-sbcl](https://github.com/smashedtoatoms/asdf-sbcl)                                           |
 | step                          | [log2/asdf-step](https://github.com/log2/asdf-step)                                                               |
 | Stern                         | [looztra/asdf-stern](https://github.com/looztra/asdf-stern)                                                       |
-| stratus-red-team              | [vthiery/asdf-stratus-red-team](https://github.com/vthiery/asdf-stratus-red-team)                                 |
+| stratus-red-team              | [asdf-community/asdf-stratus-red-team](https://github.com/asdf-community/asdf-stratus-red-team)                   |
 | stripe-cli                    | [offbyone/asdf-stripe](https://github.com/offbyone/asdf-stripe)                                                   |
 | stylua                        | [jc00ke/asdf-stylua](https://github.com/jc00ke/asdf-stylua)                                                       |
 | svu                           | [asdf-community/asdf-svu](https://github.com/asdf-community/asdf-svu)                                             |

--- a/plugins/stratus-red-team
+++ b/plugins/stratus-red-team
@@ -1,0 +1,1 @@
+repository = https://github.com/vthiery/asdf-stratus-red-team.git

--- a/plugins/stratus-red-team
+++ b/plugins/stratus-red-team
@@ -1,1 +1,1 @@
-repository = https://github.com/vthiery/asdf-stratus-red-team.git
+repository = https://github.com/asdf-community/asdf-stratus-red-team.git


### PR DESCRIPTION
## Summary

Description:

- Tool repo URL: https://github.com/DataDog/stratus-red-team
- Plugin repo URL: https://github.com/vthiery/asdf-stratus-red-team

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/stratus-red-team`
- [x] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_