### PR TITLE
feat: Add ruff plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -603,6 +603,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | rstash                        | [carlduevel/asdf-rstash](https://github.com/carlduevel/asdf-rstash)                                               |
 | rlwrap                        | [asdf-community/asdf-rlwrap](https://github.com/asdf-community/asdf-rlwrap)                                       |
 | Ruby                          | [asdf-vm/asdf-ruby](https://github.com/asdf-vm/asdf-ruby)                                                         |
+| ruff                          | [simhem/asdf-ruff](https://github.com/simhem/asdf-ruff)                                                           |
 | Rust                          | [code-lever/asdf-rust](https://github.com/code-lever/asdf-rust)                                                   |
 | rust-analyzer                 | [Xyven1/asdf-rust-analyzer](https://github.com/Xyven1/asdf-rust-analyzer)                                         |
 | rye                           | [Azuki-bar/asdf-rye](https://github.com/Azuki-bar/asdf-rye)                                                       |

--- a/plugins/ruff
+++ b/plugins/ruff
@@ -1,0 +1,1 @@
+repository = https://github.com/simhem/asdf-ruff


### PR DESCRIPTION
## Summary

Description:

- Tool repo URL: https://github.com/asdf-vm/asdf
- Plugin repo URL: https://github.com/simhem/asdf-ruff

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
