### PR TITLE
feat: add liquibase plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,6 +453,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | Link (system tools)           | [asdf-community/asdf-link](https://github.com/asdf-community/asdf-link)                                           |
 | Linkerd                       | [kforsthoevel/asdf-linkerd](https://github.com/kforsthoevel/asdf-linkerd)                                         |
 | liqoctl                       | [pdemagny/asdf-liqoctl](https://github.com/pdemagny/asdf-liqoctl)                                                 |
+| liquibase                     | [saliougaye/asdf-liquibase](https://github.com/saliougaye/asdf-liquibase)                                         |
 | Litestream                    | [threkk/asdf-litestream](https://github.com/threkk/asdf-litestream)                                               |
 | Logtalk                       | [LogtalkDotOrg/asdf-logtalk](https://github.com/LogtalkDotOrg/asdf-logtalk)                                       |
 | Loki-Logcli                   | [comdotlinux/asdf-loki-logcli](https://github.com/comdotlinux/asdf-loki-logcli)                                   |

--- a/plugins/liquibase
+++ b/plugins/liquibase
@@ -1,0 +1,1 @@
+repository = https://github.com/saliougaye/asdf-liquibase.git


### PR DESCRIPTION
## Summary

Description:

- Tool repo URL: https://github.com/liquibase/liquibase
- Plugin repo URL: https://github.com/saliougaye/asdf-liquibase

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_
