### PR TITLE
feat:  add process-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -609,7 +609,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | powerline-go                  | [dex4er/asdf-powerline-go](https://github.com/dex4er/asdf-powerline-go)                                           |
 | PowerShell                    | [daveneeley/asdf-powershell-core](https://github.com/daveneeley/asdf-powershell-core)                             |
 | pre-commit                    | [jonathanmorley/asdf-pre-commit](https://github.com/jonathanmorley/asdf-pre-commit)                               |
-| process-compose               | [martino/asdf-process-compose](https://github.com/martino/asdf-process-compose)                                   |        
+| process-compose               | [martino/asdf-process-compose](https://github.com/martino/asdf-process-compose)                                   |
 | promtool                      | [asdf-community/asdf-promtool](https://github.com/asdf-community/asdf-promtool)                                   |
 | protoc                        | [paxosglobal/asdf-protoc](https://github.com/paxosglobal/asdf-protoc)                                             |
 | protoc-gen-connect-go         | [dylanrayboss/asdf-protoc-gen-connect-go](https://github.com/dylanrayboss/asdf-protoc-gen-connect-go)             |

--- a/README.md
+++ b/README.md
@@ -559,6 +559,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | powerline-go                  | [dex4er/asdf-powerline-go](https://github.com/dex4er/asdf-powerline-go)                                           |
 | PowerShell                    | [daveneeley/asdf-powershell-core](https://github.com/daveneeley/asdf-powershell-core)                             |
 | pre-commit                    | [jonathanmorley/asdf-pre-commit](https://github.com/jonathanmorley/asdf-pre-commit)                               |
+| process-compose               | [martino/asdf-process-compose](https://github.com/martino/asdf-process-compose)                                   |        
 | promtool                      | [asdf-community/asdf-promtool](https://github.com/asdf-community/asdf-promtool)                                   |
 | protoc                        | [paxosglobal/asdf-protoc](https://github.com/paxosglobal/asdf-protoc)                                             |
 | protoc-gen-connect-go         | [dylanrayboss/asdf-protoc-gen-connect-go](https://github.com/dylanrayboss/asdf-protoc-gen-connect-go)             |

--- a/plugins/process-compose
+++ b/plugins/process-compose
@@ -1,0 +1,1 @@
+repository = https://github.com/martino/asdf-process-compose


### PR DESCRIPTION
## Summary

Description:

- Tool repo URL: https://github.com/F1bonacc1/process-compose
- Plugin repo URL: https://github.com/martino/asdf-process-compose

## Checklist

- [ ] Format with `scripts/format.bash`
- [ ] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [ ] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
