### PR TITLE
feat: adds yamlscript plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -770,6 +770,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | yadm                          | [particledecay/asdf-yadm](https://github.com/particledecay/asdf-yadm)                                             |
 | yamlfmt                       | [kachick/asdf-yamlfmt](https://github.com/kachick/asdf-yamlfmt)                                                   |
 | yamllint                      | [ericcornelissen/asdf-yamllint](https://github.com/ericcornelissen/asdf-yamllint)                                 |
+| yamlscript                    | [FeryET/asdf-yamlscript](https://github.com/FeryET/asdf-yamlscript)                                               |
 | Yarn                          | [twuni/asdf-yarn](https://github.com/twuni/asdf-yarn)                                                             |
 | yay                           | [aaaaninja/asdf-yay](https://github.com/aaaaninja/asdf-yay)                                                       |
 | Yor                           | [ordinaryexperts/asdf-yor](https://github.com/ordinaryexperts/asdf-yor)                                           |

--- a/plugins/yamlscript
+++ b/plugins/yamlscript
@@ -1,0 +1,1 @@
+repository = https://github.com/FeryET/asdf-yamlscript.git


### PR DESCRIPTION
## Adds yamlscript asdf plugin

- Tool repo URL: https://github.com/yaml/yamlscript
- Plugin repo URL: https://github.com/FeryET/asdf-yamlscript/

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green

<!-- Thank you for contributing to asdf-plugins! -->
