### PR TITLE
feat: add k3kcli plugin repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,6 +381,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | k0sctl                        | [Its-Alex/asdf-plugin-k0sctl](https://github.com/Its-Alex/asdf-plugin-k0sctl)                                     |
 | k2tf                          | [carlduevel/asdf-k2tf](https://github.com/carlduevel/asdf-k2tf)                                                   |
 | k3d                           | [spencergilbert/asdf-k3d](https://github.com/spencergilbert/asdf-k3d)                                             |
+| k3kcli                        | [xanmanning/asdf-k3kcli](https://github.com/xanmanning/asdf-k3kcli)                                               |
 | k3sup                         | [cgroschupp/asdf-k3sup](https://github.com/cgroschupp/asdf-k3sup)                                                 |
 | k6                            | [grimoh/asdf-k6](https://github.com/grimoh/asdf-k6)                                                               |
 | k9s                           | [looztra/asdf-k9s](https://github.com/looztra/asdf-k9s)                                                           |

--- a/plugins/k3kcli
+++ b/plugins/k3kcli
@@ -1,0 +1,1 @@
+repository = https://github.com/xanmanning/asdf-k3kcli.git


### PR DESCRIPTION
## Summary

Description:

- Tool repo URL: https://github.com/rancher/k3k
- Plugin repo URL: https://github.com/xanmanning/asdf-k3kcli

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
