### PR TITLE
feat: add jnv plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,6 +370,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | jiq                           | [chessmango/asdf-jiq](https://github.com/chessmango/asdf-jiq)                                                     |
 | jless                         | [jc00ke/asdf-jless](https://github.com/jc00ke/asdf-jless)                                                         |
 | JMESPath                      | [skyzyx/asdf-jmespath](https://github.com/skyzyx/asdf-jmespath)                                                   |
+| jnv                           | [raimon49/asdf-jnv](https://github.com/raimon49/asdf-jnv)                                                         |
 | jq                            | [lsanwick/asdf-jq](https://github.com/lsanwick/asdf-jq)                                                           |
 | jqp                           | [wt0f/asdf-jqp](https://gitlab.com/wt0f/asdf-jqp)                                                                 |
 | JReleaser                     | [joschi/asdf-jreleaser](https://github.com/joschi/asdf-jreleaser)                                                 |

--- a/plugins/jnv
+++ b/plugins/jnv
@@ -1,0 +1,1 @@
+repository = https://github.com/raimon49/asdf-jnv.git


### PR DESCRIPTION
## Summary

Description:

- Tool repo URL:https://github.com/ynqa/jnv
- Plugin repo URL:https://github.com/raimon49/asdf-jnv

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

This is the result of a test run.

```bash
$ scripts/test_plugin.bash --file plugins/jnv
OK plugins/jnv
```
