### PR TITLE
feat: add git-cliff asdf plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | ginkgo                        | [jimmidyson/asdf-ginkgo](https://github.com/jimmidyson/asdf-ginkgo)                                               |
 | git                           | [jcaigitlab/asdf-git](https://gitlab.com/jcaigitlab/asdf-git)                                                     |
 | git-chglog                    | [GoodwayGroup/asdf-git-chglog](https://github.com/GoodwayGroup/asdf-git-chglog)                                   |
+| git-cliff                     | [jylenhof/asdf-git-cliff](https://github.com/jylenhof/asdf-git-cliff)                                             |
 | gitconfig                     | [0ghny/asdf-gitconfig](https://github.com/0ghny/asdf-gitconfig)                                                   |
 | GitHub CLI                    | [bartlomiejdanek/asdf-github-cli](https://github.com/bartlomiejdanek/asdf-github-cli)                             |
 | GitHub Markdown ToC           | [skyzyx/asdf-github-markdown-toc](https://github.com/skyzyx/asdf-github-markdown-toc)                             |

--- a/plugins/git-cliff
+++ b/plugins/git-cliff
@@ -1,0 +1,1 @@
+repository = https://github.com/jylenhof/asdf-git-cliff.git


### PR DESCRIPTION
## Summary

Description:

- Tool repo URL: https://github.com/orhun/git-cliff
- Plugin repo URL: https://github.com/jylenhof/asdf-git-cliff

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
