### PR TITLE
feat: add apollo-ios-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | ant                           | [jackboespflug/asdf-ant](https://github.com/jackboespflug/asdf-ant)                                               |
 | Apache Jmeter                 | [comdotlinux/asdf-jmeter](https://github.com/comdotlinux/asdf-jmeter)                                             |
 | apko                          | [omissis/asdf-apko](https://github.com/omissis/asdf-apko)                                                         |
+| apollo-ios-cli                | [MacPaw/asdf-apollo-ios-cli](https://github.com/MacPaw/asdf-apollo-ios-cli)                                       |
 | Apollo Router                 | [safx/asdf-apollo-router](https://github.com/safx/asdf-apollo-router)                                             |
 | arc                           | [ORCID/asdf-arc](https://github.com/ORCID/asdf-arc)                                                               |
 | argo                          | [sudermanjr/asdf-argo](https://github.com/sudermanjr/asdf-argo)                                                   |

--- a/plugins/apollo-ios-cli
+++ b/plugins/apollo-ios-cli
@@ -1,0 +1,1 @@
+repository = https://github.com/MacPaw/asdf-apollo-ios-cli


### PR DESCRIPTION
## Summary

Description:

- Tool repo URL: https://github.com/apollographql/apollo-ios-codegen, but binaries distributed in https://github.com/apollographql/apollo-ios
- Plugin repo URL: https://github.com/MacPaw/asdf-apollo-ios-cli

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
