### PR TITLE
feat: add xcbeautify

### DIFF
--- a/README.md
+++ b/README.md
@@ -789,6 +789,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | XCTestHTMLReport              | [younke/asdf-xchtmlreport](https://github.com/younke/asdf-xchtmlreport)                                           |
 | XcodeGen                      | [younke/asdf-xcodegen](https://github.com/younke/asdf-xcodegen)                                                   |
 | xc                            | [airtonix/asdf-xc](https://github.com/airtonix/asdf-xc)                                                           |
+| xcbeautify                    | [MacPaw/asdf-xcbeautify](https://github.com/MacPaw/asdf-xcbeautify)                                               |
 | xcodes                        | [younke/asdf-xcodes](https://github.com/younke/asdf-xcodes)                                                       |
 | xh                            | [NeoHsu/asdf-xh](https://github.com/NeoHsu/asdf-xh)                                                               |
 | yadm                          | [particledecay/asdf-yadm](https://github.com/particledecay/asdf-yadm)                                             |

--- a/plugins/xcbeautify
+++ b/plugins/xcbeautify
@@ -1,0 +1,1 @@
+repository = https://github.com/MacPaw/asdf-xcbeautify.git


### PR DESCRIPTION
## Summary

Description:

- Tool repo URL: https://github.com/cpisciotta/xcbeautify
- Plugin repo URL: https://github.com/MacPaw/asdf-xcbeautify

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
