### PR TITLE
feat: add asdf sync plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -694,6 +694,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | Swiftlint                     | [klundberg/asdf-swiftlint](https://github.com/klundberg/asdf-swiftlint)                                           |
 | SWIProlog                     | [mracos/asdf-swiprolog](https://github.com/mracos/asdf-swiprolog)                                                 |
 | syft                          | [davidgp1701/asdf-syft](https://github.com/davidgp1701/asdf-syft)                                                 |
+| sync                          | [robzr/asdf-sync](https://github.com/robzr/asdf-sync)                                                             |
 | syncher                       | [nwillc/syncher](https://github.com/nwillc/syncher)                                                               |
 | talhelper                     | [bjw-s/asdf-talhelper](https://github.com/bjw-s/asdf-talhelper)                                                   |
 | Talos                         | [particledecay/asdf-talos](https://github.com/particledecay/asdf-talos)                                           |

--- a/plugins/sync
+++ b/plugins/sync
@@ -1,0 +1,1 @@
+repository = https://github.com/robzr/asdf-sync


### PR DESCRIPTION
## Summary

Description: `asdf sync` is a plugin which implements an asdf extension command to synchronize plugins. It also offers the ability to use Semantic Versioning based version constraints using common constraint syntax, and to specify a plugin URL and/or ref in the comments of .tool-versions.

- Tool repo URL: https://github.com/robzr/asdf-sync
- Plugin repo URL: https://github.com/robzr/asdf-sync

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
