### PR TITLE
feat: add xcresultparser

### DIFF
--- a/README.md
+++ b/README.md
@@ -790,6 +790,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | XcodeGen                      | [younke/asdf-xcodegen](https://github.com/younke/asdf-xcodegen)                                                   |
 | xc                            | [airtonix/asdf-xc](https://github.com/airtonix/asdf-xc)                                                           |
 | xcodes                        | [younke/asdf-xcodes](https://github.com/younke/asdf-xcodes)                                                       |
+| xcresultparser                | [MacPaw/asdf-xcresultparser](https://github.com/MacPaw/asdf-xcresultparser)                                       |
 | xh                            | [NeoHsu/asdf-xh](https://github.com/NeoHsu/asdf-xh)                                                               |
 | yadm                          | [particledecay/asdf-yadm](https://github.com/particledecay/asdf-yadm)                                             |
 | yamlfmt                       | [kachick/asdf-yamlfmt](https://github.com/kachick/asdf-yamlfmt)                                                   |

--- a/plugins/xcresultparser
+++ b/plugins/xcresultparser
@@ -1,0 +1,1 @@
+repository = https://github.com/MacPaw/asdf-xcresultparser.git


### PR DESCRIPTION
## Summary

Description:

- Tool repo URL: https://github.com/a7ex/xcresultparser
- Plugin repo URL: https://github.com/MacPaw/asdf-xcresultparser

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
