### PR TITLE
feat: remove `bin`

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,6 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | bbr-s3-config-validator       | [vmware-tanzu/tanzu-plug-in-for-asdf](https://github.com/vmware-tanzu/tanzu-plug-in-for-asdf)                     |
 | benthos                       | [benthosdev/benthos-asdf](https://github.com/benthosdev/benthos-asdf)                                             |
 | bfs                           | [virtualroot/asdf-bfs](https://github.com/virtualroot/asdf-bfs)                                                   |
-| Bin                           | [yozachar/asdf-bin](https://github.com/yozachar/asdf-bin)                                                         |
 | binnacle                      | [Traackr/asdf-binnacle](https://github.com/Traackr/asdf-binnacle)                                                 |
 | Bitwarden                     | [vixus0/asdf-bitwarden](https://github.com/vixus0/asdf-bitwarden)                                                 |
 | bitwarden-secrets-manager     | [asdf-community/asdf-bitwarden-secrets-manager](https://github.com/asdf-community/asdf-bitwarden-secrets-manager) |

--- a/plugins/bin
+++ b/plugins/bin
@@ -1,1 +1,0 @@
-repository = https://github.com/yozachar/asdf-bin.git


### PR DESCRIPTION
## Summary

Description: Remove `bin` plugin, 'cause it not meant to be used in a versioned manner. See: https://github.com/marcosnils/bin/issues/164

- Tool repo URL: https://github.com/marcosnils/bin
- Plugin repo URL: No longer exists.

## Checklist

- [X] Format with `scripts/format.bash`
- [X] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [X] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
