### PR TITLE
feat: replace pandoc plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -555,7 +555,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | osqueryi                      | [davidecavestro/asdf-osqueryi](https://github.com/davidecavestro/asdf-osqueryi)                                   |
 | pachctl                       | [abatilo/asdf-pachctl](https://github.com/abatilo/asdf-pachctl)                                                   |
 | Packer                        | [asdf-community/asdf-hashicorp](https://github.com/asdf-community/asdf-hashicorp)                                 |
-| Pandoc                        | [Fbrisset/asdf-pandoc](https://github.com/Fbrisset/asdf-pandoc)                                                   |
+| Pandoc                        | [sys9kdr/asdf-pandoc](https://github.com/sys9kdr/asdf-pandoc)                                                     |
 | patat                         | [airtonix/asdf-patat](https://github.com/airtonix/asdf-patat)                                                     |
 | peco                          | [asdf-community/asdf-peco](https://github.com/asdf-community/asdf-peco)                                           |
 | pdm                           | [1oglop1/asdf-pdm](https://github.com/1oglop1/asdf-pdm)                                                           |

--- a/plugins/pandoc
+++ b/plugins/pandoc
@@ -1,1 +1,1 @@
-repository = https://github.com/Fbrisset/asdf-pandoc.git
+repository = https://github.com/sys9kdr/asdf-pandoc.git


### PR DESCRIPTION
## Summary

Description:

- Tool repo URL: https://github.com/jgm/pandoc
- Plugin repo URL: https://github.com/sys9kdr/asdf-pandoc

ref #995 

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
