### PR TITLE
feat: add pandoc-crossref plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -556,6 +556,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | pachctl                       | [abatilo/asdf-pachctl](https://github.com/abatilo/asdf-pachctl)                                                   |
 | Packer                        | [asdf-community/asdf-hashicorp](https://github.com/asdf-community/asdf-hashicorp)                                 |
 | Pandoc                        | [Fbrisset/asdf-pandoc](https://github.com/Fbrisset/asdf-pandoc)                                                   |
+| pandoc-crossref               | [sys9kdr/asdf-pandoc-crossref](https://github.com/sys9kdr/asdf-pandoc-crossref)                                   |
 | patat                         | [airtonix/asdf-patat](https://github.com/airtonix/asdf-patat)                                                     |
 | peco                          | [asdf-community/asdf-peco](https://github.com/asdf-community/asdf-peco)                                           |
 | pdm                           | [1oglop1/asdf-pdm](https://github.com/1oglop1/asdf-pdm)                                                           |

--- a/plugins/pandoc-crossref
+++ b/plugins/pandoc-crossref
@@ -1,0 +1,1 @@
+repository = https://github.com/Fbrisset/asdf-pandoc.git

--- a/plugins/pandoc-crossref
+++ b/plugins/pandoc-crossref
@@ -1,1 +1,1 @@
-repository = https://github.com/Fbrisset/asdf-pandoc.git
+repository = https://github.com/sys9kdr/asdf-pandoc-crossref


### PR DESCRIPTION
## Summary

Description:

- Tool repo URL: https://github.com/lierdakil/pandoc-crossref
- Plugin repo URL: https://github.com/sys9kdr/asdf-pandoc-crossref

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
