### PR TITLE
feat: add mirantis launchpad plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,6 +456,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | kwt                           | [vmware-tanzu/asdf-carvel](https://github.com/vmware-tanzu/asdf-carvel)                                           |
 | lab                           | [particledecay/asdf-lab](https://github.com/particledecay/asdf-lab)                                               |
 | lane                          | [CodeReaper/asdf-lane](https://github.com/CodeReaper/asdf-lane)                                                   |
+| launchpad                     | [surskitt/asdf-launchpad](https://github.com/surskitt/asdf-launchpad)                                             |
 | lazygit                       | [nklmilojevic/asdf-lazygit](https://github.com/nklmilojevic/asdf-lazygit)                                         |
 | Lean                          | [asdf-community/asdf-lean](https://github.com/asdf-community/asdf-lean)                                           |
 | Leiningen                     | [miorimmax/asdf-lein](https://github.com/miorimmax/asdf-lein)                                                     |

--- a/plugins/launchpad
+++ b/plugins/launchpad
@@ -1,0 +1,1 @@
+repository = https://github.com/surskitt/asdf-launchpad.git


### PR DESCRIPTION
## Summary

Description:

- Tool repo URL: https://github.com/Mirantis/launchpad
- Plugin repo URL: https://github.com/surskitt/asdf-launchpad

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
