### PR TITLE
fix: update plugins owner for cargo-make, yamlfmt and zigmod

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | CalendarSync                  | [FeryET/asdf-calendarsync](https://github.com/FeryET/asdf-calendarsync)                                           |
 | Calicoctl                     | [FairwindsOps/asdf-calicoctl](https://github.com/FairwindsOps/asdf-calicoctl)                                     |
 | Camunda Modeler               | [barmac/asdf-camunda-modeler](https://github.com/barmac/asdf-camunda-modeler)                                     |
-| cargo-make                    | [kachick/asdf-cargo-make](https://github.com/kachick/asdf-cargo-make)                                             |
+| cargo-make                    | [mise-plugins/asdf-cargo-make](https://github.com/mise-plugins/asdf-cargo-make)                                   |
 | Carp                          | [susurri/asdf-carp](https://github.com/susurri/asdf-carp)                                                         |
 | carthage                      | [younke/asdf-carthage](https://github.com/younke/asdf-carthage)                                                   |
 | ccache                        | [asdf-community/asdf-ccache](https://github.com/asdf-community/asdf-ccache)                                       |
@@ -792,7 +792,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | xcodes                        | [younke/asdf-xcodes](https://github.com/younke/asdf-xcodes)                                                       |
 | xh                            | [NeoHsu/asdf-xh](https://github.com/NeoHsu/asdf-xh)                                                               |
 | yadm                          | [particledecay/asdf-yadm](https://github.com/particledecay/asdf-yadm)                                             |
-| yamlfmt                       | [kachick/asdf-yamlfmt](https://github.com/kachick/asdf-yamlfmt)                                                   |
+| yamlfmt                       | [mise-plugins/asdf-yamlfmt](https://github.com/mise-plugins/asdf-yamlfmt)                                         |
 | yamllint                      | [ericcornelissen/asdf-yamllint](https://github.com/ericcornelissen/asdf-yamllint)                                 |
 | yamlscript                    | [FeryET/asdf-yamlscript](https://github.com/FeryET/asdf-yamlscript)                                               |
 | Yarn                          | [twuni/asdf-yarn](https://github.com/twuni/asdf-yarn)                                                             |
@@ -807,7 +807,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | zellij                        | [chessmango/asdf-zellij](https://github.com/chessmango/asdf-zellij)                                               |
 | Zephyr                        | [nsaunders/asdf-zephyr](https://github.com/nsaunders/asdf-zephyr)                                                 |
 | Zig                           | [cheetah/asdf-zig](https://github.com/cheetah/asdf-zig)                                                           |
-| zigmod                        | [kachick/asdf-zigmod](https://github.com/kachick/asdf-zigmod)                                                     |
+| zigmod                        | [mise-plugins/asdf-zigmod](https://github.com/mise-plugins/asdf-zigmod)                                           |
 | Zola                          | [salasrod/asdf-zola](https://github.com/salasrod/asdf-zola)                                                       |
 | zoxide                        | [nyrst/asdf-zoxide](https://github.com/nyrst/asdf-zoxide)                                                         |
 | zprint                        | [carlduevel/asdf-zprint](https://github.com/carlduevel/asdf-zprint)                                               |

--- a/plugins/cargo-make
+++ b/plugins/cargo-make
@@ -1,1 +1,1 @@
-repository = https://github.com/kachick/asdf-cargo-make.git
+repository = https://github.com/mise-plugins/asdf-cargo-make.git

--- a/plugins/yamlfmt
+++ b/plugins/yamlfmt
@@ -1,1 +1,1 @@
-repository = https://github.com/kachick/asdf-yamlfmt.git
+repository = https://github.com/mise-plugins/asdf-yamlfmt.git

--- a/plugins/zigmod
+++ b/plugins/zigmod
@@ -1,1 +1,1 @@
-repository = https://github.com/kachick/asdf-zigmod.git
+repository = https://github.com/mise-plugins/asdf-zigmod.git


### PR DESCRIPTION
## Summary

Description:

https://github.com/orgs/mise-plugins/discussions/13

I have transferred repository owner of my plugins for a community. 

## Checklist

- [x] Format with `scripts/format.bash`

<!-- Thank you for contributing to asdf-plugins! -->
