### PR TITLE
feat: asdf-jetbrains plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,6 +374,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | Java                          | [halcyon/asdf-java](https://github.com/halcyon/asdf-java)                                                         |
 | jb                            | [beardix/asdf-jb](https://github.com/beardix/asdf-jb)                                                             |
 | jbang                         | [jbangdev/jbang-asdf](https://github.com/jbangdev/jbang-asdf)                                                     |
+| jetbrains                     | [asdf-community/asdf-jetbrains](https://github.com/asdf-community/asdf-jetbrains)                                 |
 | jfrog-cli                     | [LozanoMatheus/asdf-jfrog-cli](https://github.com/LozanoMatheus/asdf-jfrog-cli)                                   |
 | jib                           | [joschi/asdf-jib](https://github.com/joschi/asdf-jib)                                                             |
 | jiq                           | [chessmango/asdf-jiq](https://github.com/chessmango/asdf-jiq)                                                     |

--- a/plugins/jetbrains
+++ b/plugins/jetbrains
@@ -1,0 +1,1 @@
+repository = https://github.com/asdf-community/asdf-jetbrains


### PR DESCRIPTION
## Summary

ASDF plugin for JetBrains tools:

- clion      - CLion
- datagrip   - DataGrip
- dataspell  - DataSpell
- gateway    - Gateway
- goland     - GoLand
- idea       - IntelliJ IDEA Ultimate
- ideac      - IntelliJ IDEA Community Edition
- mps        - MPS
- phpstorm   - PhpStorm
- pycharm    - PyCharm Professional Edition
- pycharmc   - PyCharm Community Edition
- rider      - Rider
- rideru     - Rider for Unreal Engine
- rubymine   - RubyMine
- webstorm   - WebStorm

## Description:

- JetBrains products: https://www.jetbrains.com/products/
- Plugin repo URL: https://github.com/asdf-community/asdf-jetbrains

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green

