### PR TITLE
feat: add dojo plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | doctl                         | [maristgeek/asdf-doctl](https://github.com/maristgeek/asdf-doctl)                                                 |
 | docToolchain                  | [joschi/asdf-doctoolchain](https://github.com/joschi/asdf-doctoolchain)                                           |
 | docuum                        | [bradym/asdf-docuum](https://github.com/bradym/asdf-docuum)                                                       |
+| dojo                          | [dojoengine/asdf-dojo](https://github.com/dojoengine/asdf-dojo)                                                   |
 | DOME                          | [jtakakura/asdf-dome](https://github.com/jtakakura/asdf-dome)                                                     |
 | doppler                       | [takutakahashi/asdf-doppler](https://github.com/takutakahashi/asdf-doppler)                                       |
 | dotenv-linter                 | [wesleimp/asdf-dotenv-linter](https://github.com/wesleimp/asdf-dotenv-linter)                                     |

--- a/plugins/dojo
+++ b/plugins/dojo
@@ -1,0 +1,1 @@
+repository = https://github.com/dojoengine/asdf-dojo.git


### PR DESCRIPTION
## Summary

Description:

- Tool repo URL: https://github.com/dojoengine/dojo
- Plugin repo URL: https://github.com/dojoengine/asdf-dojo/

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
