### PR TITLE
feat: add asdf-e1s plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | DVC                           | [fwfurtado/asdf-dvc](https://github.com/fwfurtado/asdf-dvc)                                                       |
 | dyff                          | [wt0f/asdf-dyff](https://gitlab.com/wt0f/asdf-dyff)                                                               |
 | dynatrace-monaco              | [nsaputro/asdf-monaco](https://github.com/nsaputro/asdf-monaco)                                                   |
+| e1s                           | [tbobm/asdf-e1s](https://github.com/tbobm/asdf-e1s)                                                               |
 | earthly                       | [YR-ZR0/asdf-earthly](https://github.com/YR-ZR0/asdf-earthly)                                                     |
 | ecspresso                     | [kayac/asdf-ecspresso](https://github.com/kayac/asdf-ecspresso)                                                   |
 | editorconfig-checker          | [gabitchov/asdf-editorconfig-checker](https://github.com/gabitchov/asdf-editorconfig-checker)                     |

--- a/plugins/e1s
+++ b/plugins/e1s
@@ -1,0 +1,1 @@
+repository = https://github.com/tbobm/asdf-e1s


### PR DESCRIPTION
## Summary

Description:

- Tool repo URL: https://github.com/keidarcy/e1s
- Plugin repo URL: https://github.com/tbobm/asdf-e1s

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
