### PR TITLE
fix: change spark plugin to fixed fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -664,7 +664,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | Sourcery                      | [younke/asdf-sourcery](https://github.com/younke/asdf-sourcery)                                                   |
 | spacectl                      | [bodgit/asdf-spacectl](https://github.com/bodgit/asdf-spacectl)                                                   |
 | Spago                         | [jrrom/asdf-spago](https://github.com/jrrom/asdf-spago)                                                           |
-| Spark                         | [joshuaballoch/asdf-spark](https://github.com/joshuaballoch/asdf-spark)                                           |
+| Spark                         | [joshuaballoch/asdf-spark](https://github.com/sudo-black/asdf-spark)                                              |
 | Spectral                      | [vbyrd/asdf-spectral](https://github.com/vbyrd/asdf-spectral)                                                     |
 | Spin                          | [pavloos/asdf-spin](https://github.com/pavloos/asdf-spin)                                                         |
 | Spring Boot CLI               | [joschi/asdf-spring-boot](https://github.com/joschi/asdf-spring-boot)                                             |

--- a/plugins/spark
+++ b/plugins/spark
@@ -1,1 +1,1 @@
-repository = https://github.com/joshuaballoch/asdf-spark.git
+repository = https://github.com/sudo-black/asdf-spark.git


### PR DESCRIPTION
## Summary

Description:

- Tool repo URL: https://github.com/sudo-black/asdf-spark.git
- Plugin repo URL: https://github.com/sudo-black/asdf-spark.git

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
