### PR TITLE
feat: add versio

### DIFF
--- a/README.md
+++ b/README.md
@@ -766,6 +766,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | Velero                        | [looztra/asdf-velero](https://github.com/looztra/asdf-velero)                                                     |
 | vendir                        | [vmware-tanzu/asdf-carvel](https://github.com/vmware-tanzu/asdf-carvel)                                           |
 | Venom                         | [aabouzaid/asdf-venom](https://github.com/aabouzaid/asdf-venom)                                                   |
+| versio                        | [pdemagny/asdf-versio](https://github.com/pdemagny/asdf-versio)                                                   |
 | vcluster                      | [wt0f/asdf-vcluster](https://gitlab.com/wt0f/asdf-vcluster)                                                       |
 | vela                          | [pdemagny/asdf-vela](https://github.com/pdemagny/asdf-vela)                                                       |
 | velad                         | [pdemagny/asdf-velad](https://github.com/pdemagny/asdf-velad)                                                     |

--- a/plugins/versio
+++ b/plugins/versio
@@ -1,0 +1,1 @@
+repository = https://github.com/pdemagny/asdf-versio.git


### PR DESCRIPTION
## Summary

Description:

- Tool repo URL: https://github.com/chaaz/versio
- Plugin repo URL: https://github.com/pdemagny/asdf-versio

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

(The CI on the plugin is not green for MacOS because of missing openssl lib on the runner, but the asdf plugin itself downloads the binary as it should).