### PR TITLE
feat: add starkli plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -674,6 +674,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | sshuttle                      | [xanmanning/asdf-sshuttle](https://github.com/xanmanning/asdf-sshuttle)                                           |
 | Stack                         | [sestrella/asdf-ghcup](https://github.com/sestrella/asdf-ghcup)                                                   |
 | starboard                     | [zufardhiyaulhaq/asdf-starboard](https://github.com/zufardhiyaulhaq/asdf-starboard)                               |
+| Starkli                       | [ptisserand/asdf-starkli](https://github.com/ptisserand/asdf-starkli)                                             |
 | Starknet Foundry              | [foundry-rs/asdf-starknet-foundry](https://github.com/foundry-rs/asdf-starknet-foundry)                           |
 | starport                      | [nikever/asdf-starport](https://github.com/nikever/asdf-starport)                                                 |
 | starship                      | [gr1m0h/asdf-starship](https://github.com/gr1m0h/asdf-starship)                                                   |

--- a/plugins/starkli
+++ b/plugins/starkli
@@ -1,0 +1,1 @@
+repository = https://github.com/ptisserand/asdf-starkli


### PR DESCRIPTION
## Summary

Description: CLI tool for Starknet

- Tool repo URL: https://github.com/xJonathanLEI/starkli
- Plugin repo URL: https://github.com/ptisserand/asdf-starkli

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
