### PR TITLE
feat: add starknet-devnet plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -674,6 +674,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | sshuttle                      | [xanmanning/asdf-sshuttle](https://github.com/xanmanning/asdf-sshuttle)                                           |
 | Stack                         | [sestrella/asdf-ghcup](https://github.com/sestrella/asdf-ghcup)                                                   |
 | starboard                     | [zufardhiyaulhaq/asdf-starboard](https://github.com/zufardhiyaulhaq/asdf-starboard)                               |
+| Starknet Devnet               | [ptisserand/asdf-starknet-devnet](https://github.com/ptisserand/asdf-starknet-devnet)                             |
 | Starknet Foundry              | [foundry-rs/asdf-starknet-foundry](https://github.com/foundry-rs/asdf-starknet-foundry)                           |
 | starport                      | [nikever/asdf-starport](https://github.com/nikever/asdf-starport)                                                 |
 | starship                      | [gr1m0h/asdf-starship](https://github.com/gr1m0h/asdf-starship)                                                   |

--- a/plugins/starknet-devnet
+++ b/plugins/starknet-devnet
@@ -1,0 +1,1 @@
+repository = https://github.com/ptisserand/asdf-starknet-devnet


### PR DESCRIPTION
## Summary

Description: A local testnet for Starknet... in Rust

- Tool repo URL: https://github.com/0xSpaceShard/starknet-devnet-rs
- Plugin repo URL: https://github.com/ptisserand/asdf-starknet-devnet

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
