### PR TITLE
feat: Add asdf-pixi

### DIFF
--- a/README.md
+++ b/README.md
@@ -566,6 +566,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | pipelight                     | [kogeletey/asdf-pipelight](https://github.com/kogeletey/asdf-pipelight)                                           |
 | pipx                          | [yozachar/asdf-pipx](https://github.com/yozachar/asdf-pipx)                                                       |
 | pivnet                        | [vmware-tanzu/tanzu-plug-in-for-asdf](https://github.com/vmware-tanzu/tanzu-plug-in-for-asdf)                     |
+| pixi                          | [pavelzw/pixi](https://github.com/pavelzw/asdf-pixi)                                                                   |
 | pkl                           | [mise-plugins/asdf-pkl](https://github.com/mise-plugins/asdf-pkl)                                                 |
 | Please                        | [asdf-community/asdf-please](https://github.com/asdf-community/asdf-please)                                       |
 | Pluto                         | [FairwindsOps/asdf-pluto](https://github.com/FairwindsOps/asdf-pluto)                                             |

--- a/plugins/pixi
+++ b/plugins/pixi
@@ -1,0 +1,1 @@
+repository = https://github.com/pavelzw/asdf-pixi.git


### PR DESCRIPTION
## Summary

Description:

- Tool repo URL: https://github.com/prefix-dev/pixi
- Plugin repo URL: https://github.com/pavelzw/asdf-pixi

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
