### PR TITLE
feat: add the tekton-pac-cli plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -703,6 +703,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | Task                          | [particledecay/asdf-task](https://github.com/particledecay/asdf-task)                                             |
 | tctl                          | [eko/asdf-tctl](https://github.com/eko/asdf-tctl)                                                                 |
 | Tekton-cli                    | [johnhamelink/asdf-tekton-cli](https://github.com/johnhamelink/asdf-tekton-cli)                                   |
+| Tekton pipeline-as-code CLI   | [ifireball/asdf-tekton-pac-cli](https://github.com/ifireball/asdf-tekton-pac-cli)                                 |
 | Teleport Enterprise           | [highb/asdf-teleport-ent](https://github.com/highb/asdf-teleport-ent)                                             |
 | Teleport Community            | [MaloPolese/asdf-teleport-community](https://github.com/MaloPolese/asdf-teleport-community)                       |
 | telepresence                  | [pirackr/asdf-telepresence](https://github.com/pirackr/asdf-telepresence)                                         |

--- a/plugins/tekton-pac-cli
+++ b/plugins/tekton-pac-cli
@@ -1,0 +1,1 @@
+repository = https://github.com/ifireball/asdf-tekton-pac-cli.git


### PR DESCRIPTION
## Summary

Description:

- Tool repo URL:  https://github.com/openshift-pipelines/pipelines-as-code
- Plugin repo URL: https://github.com/ifireball/asdf-tekton-pac-cli.git

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
