### PR TITLE
feat: Add jet

### DIFF
--- a/README.md
+++ b/README.md
@@ -578,7 +578,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | pipelight                     | [kogeletey/asdf-pipelight](https://github.com/kogeletey/asdf-pipelight)                                           |
 | pipx                          | [yozachar/asdf-pipx](https://github.com/yozachar/asdf-pipx)                                                       |
 | pivnet                        | [vmware-tanzu/tanzu-plug-in-for-asdf](https://github.com/vmware-tanzu/tanzu-plug-in-for-asdf)                     |
-| pixi                          | [pavelzw/pixi](https://github.com/pavelzw/asdf-pixi)                                                                   |
+| pixi                          | [pavelzw/pixi](https://github.com/pavelzw/asdf-pixi)                                                              |
 | pkl                           | [mise-plugins/asdf-pkl](https://github.com/mise-plugins/asdf-pkl)                                                 |
 | Please                        | [asdf-community/asdf-please](https://github.com/asdf-community/asdf-please)                                       |
 | Pluto                         | [FairwindsOps/asdf-pluto](https://github.com/FairwindsOps/asdf-pluto)                                             |

--- a/README.md
+++ b/README.md
@@ -380,6 +380,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | Java                          | [halcyon/asdf-java](https://github.com/halcyon/asdf-java)                                                         |
 | jb                            | [beardix/asdf-jb](https://github.com/beardix/asdf-jb)                                                             |
 | jbang                         | [jbangdev/jbang-asdf](https://github.com/jbangdev/jbang-asdf)                                                     |
+| jet                           | [rynkowsg/asdf-jet](https://github.com/rynkowsg/asdf-jet)                                                         |
 | jetbrains                     | [asdf-community/asdf-jetbrains](https://github.com/asdf-community/asdf-jetbrains)                                 |
 | jfrog-cli                     | [LozanoMatheus/asdf-jfrog-cli](https://github.com/LozanoMatheus/asdf-jfrog-cli)                                   |
 | jib                           | [joschi/asdf-jib](https://github.com/joschi/asdf-jib)                                                             |

--- a/plugins/jet
+++ b/plugins/jet
@@ -1,0 +1,1 @@
+repository = https://github.com/rynkowsg/asdf-jet.git


### PR DESCRIPTION
## Summary

Description:

- Tool repo URL: https://github.com/borkdude/jet
- Plugin repo URL: https://github.com/rynkowsg/asdf-jet

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
