### PR TITLE
feat: add kubeone plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,6 +443,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | Kubelogin                     | [sechmann/asdf-kubelogin](https://github.com/sechmann/asdf-kubelogin)                                             |
 | Kubemqctl                     | [johnlayton/asdf-kubemqctl](https://github.com/johnlayton/asdf-kubemqctl)                                         |
 | kubent                        | [virtualstaticvoid/asdf-kubent](https://github.com/virtualstaticvoid/asdf-kubent)                                 |
+| kubeone                       | [PandaScience/asdf-kubeone](https://github.com/PandaScience/asdf-kubeone)                                         |
 | Kubergrunt                    | [NeoHsu/asdf-kubergrunt](https://github.com/NeoHsu/asdf-kubergrunt)                                               |
 | Kubeseal                      | [stefansedich/asdf-kubeseal](https://github.com/stefansedich/asdf-kubeseal)                                       |
 | Kubesec                       | [vitalis/asdf-kubesec](https://github.com/vitalis/asdf-kubesec)                                                   |

--- a/plugins/kubeone
+++ b/plugins/kubeone
@@ -1,0 +1,1 @@
+repository = https://github.com/PandaScience/asdf-kubeone.git


### PR DESCRIPTION
## Summary

Description:

- Tool repo URL: https://github.com/kubermatic/kubeone
- Plugin repo URL: https://github.com/PandaScience/asdf-kubeone

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
