### PR TITLE
feat: add phrase app cli plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -561,6 +561,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | pdm                           | [1oglop1/asdf-pdm](https://github.com/1oglop1/asdf-pdm)                                                           |
 | Perl                          | [ouest/asdf-perl](https://github.com/ouest/asdf-perl)                                                             |
 | PHP                           | [asdf-community/asdf-php](https://github.com/asdf-community/asdf-php)                                             |
+| Phrase                        | [bitfrost/asdf-phrase](https://github.com/bitfrost/asdf-phrase)                                                   |
 | pint                          | [sam-burrell/asdf-pint](https://github.com/sam-burrell/asdf-pint)                                                 |
 | pipectl                       | [pipe-cd/asdf-pipectl](https://github.com/pipe-cd/asdf-pipectl)                                                   |
 | pipelight                     | [kogeletey/asdf-pipelight](https://github.com/kogeletey/asdf-pipelight)                                           |

--- a/plugins/phrase
+++ b/plugins/phrase
@@ -1,0 +1,1 @@
+repository = https://github.com/bitfrost/asdf-phrase.git


### PR DESCRIPTION
## Summary
Phrase App Cli asdf plugin.  Fork of 'official one' that no longer responds to github issues.

Description:

- Tool repo URL: https://github.com/phrase/phrase-cli
- Plugin repo URL: https://github.com/bitfrost/asdf-phrase

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green
  - [x] _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
