### PR TITLE
feat: add sst plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -672,6 +672,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | sqldef                        | [cometkim/asdf-sqldef](https://github.com/cometkim/asdf-sqldef)                                                   |
 | SQLite                        | [cLupus/asdf-sqlite](https://github.com/cLupus/asdf-sqlite)                                                       |
 | sshuttle                      | [xanmanning/asdf-sshuttle](https://github.com/xanmanning/asdf-sshuttle)                                           |
+| sst                           | [nurulhudaapon/asdf-sst](https://github.com/nurulhudaapon/asdf-sst)                                               |
 | Stack                         | [sestrella/asdf-ghcup](https://github.com/sestrella/asdf-ghcup)                                                   |
 | starboard                     | [zufardhiyaulhaq/asdf-starboard](https://github.com/zufardhiyaulhaq/asdf-starboard)                               |
 | Starknet Foundry              | [foundry-rs/asdf-starknet-foundry](https://github.com/foundry-rs/asdf-starknet-foundry)                           |

--- a/plugins/sst
+++ b/plugins/sst
@@ -1,0 +1,1 @@
+repository = https://github.com/nurulhudaapon/asdf-sst.git


### PR DESCRIPTION
## Summary

Description:

- Tool repo URL: https://github.com/sst/ion
- Plugin repo URL: https://github.com/nurulhudaapon/asdf-sst

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
