### PR TITLE
feat: change mdbook plugin repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -485,7 +485,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | marp-cli                      | [xataz/asdf-marp-cli](https://github.com/xataz/asdf-marp-cli)                                                     |
 | mask                          | [aaaaninja/asdf-mask](https://github.com/aaaaninja/asdf-mask)                                                     |
 | Maven                         | [halcyon/asdf-maven](https://github.com/halcyon/asdf-maven)                                                       |
-| mdbook                        | [cipherstash/asdf-mdbook](https://github.com/cipherstash/asdf-mdbook)                                             |
+| mdbook                        | [hashemi-soroush/asdf-mdbook](https://github.com/hashemi-soroush/asdf-mdbook) |
 | mdbook-linkcheck              | [cipherstash/asdf-mdbook-linkcheck](https://github.com/cipherstash/asdf-mdbook-linkcheck)                         |
 | melange                       | [omissis/asdf-melange](https://github.com/omissis/asdf-melange)                                                   |
 | melt                          | [chessmango/asdf-melt](https://github.com/chessmango/asdf-melt)                                                   |

--- a/README.md
+++ b/README.md
@@ -485,7 +485,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | marp-cli                      | [xataz/asdf-marp-cli](https://github.com/xataz/asdf-marp-cli)                                                     |
 | mask                          | [aaaaninja/asdf-mask](https://github.com/aaaaninja/asdf-mask)                                                     |
 | Maven                         | [halcyon/asdf-maven](https://github.com/halcyon/asdf-maven)                                                       |
-| mdbook                        | [hashemi-soroush/asdf-mdbook](https://github.com/hashemi-soroush/asdf-mdbook) |
+| mdbook                        | [hashemi-soroush/asdf-mdbook](https://github.com/hashemi-soroush/asdf-mdbook)                                     |
 | mdbook-linkcheck              | [cipherstash/asdf-mdbook-linkcheck](https://github.com/cipherstash/asdf-mdbook-linkcheck)                         |
 | melange                       | [omissis/asdf-melange](https://github.com/omissis/asdf-melange)                                                   |
 | melt                          | [chessmango/asdf-melt](https://github.com/chessmango/asdf-melt)                                                   |

--- a/plugins/mdbook
+++ b/plugins/mdbook
@@ -1,1 +1,1 @@
-repository = https://github.com/cipherstash/asdf-mdbook.git
+repository = https://github.com/hashemi-soroush/asdf-mdbook.git


### PR DESCRIPTION
## Summary
The current `mdbook` plugin is based on [an archived repository](https://github.com/cipherstash-archive/asdf-mdbook). There are a couple of issues with its implementation that people have already reported and created PRs for, but the maintainer of that project hasn't responded for over a year. I forked that project and fixed those issues. This PR replaces the current mdbook plugin with my fork.

Description:

- Tool repo URL: https://github.com/rust-lang/mdBook
- Plugin repo URL: https://github.com/hashemi-soroush/asdf-plugins/

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [ ] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
