### PR TITLE
feat: add argocd-image-updater plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | argo                          | [sudermanjr/asdf-argo](https://github.com/sudermanjr/asdf-argo)                                                   |
 | argo-rollouts                 | [abatilo/asdf-argo-rollouts](https://github.com/abatilo/asdf-argo-rollouts)                                       |
 | argocd                        | [beardix/asdf-argocd](https://github.com/beardix/asdf-argocd)                                                     |
+| argocd-image-updater          | [thatmlopsguy/asdf-argocd-image-updater](https://github.com/thatmlopsguy/asdf-argocd-image-updater)               |
 | aria2                         | [asdf-community/asdf-aria2](https://github.com/asdf-community/asdf-aria2)                                         |
 | asciidoctorj                  | [gliwka/asdf-asciidoctorj](https://github.com/gliwka/asdf-asciidoctorj)                                           |
 | asdf-plugin-manager           | [asdf-community/asdf-plugin-manager](https://github.com/asdf-community/asdf-plugin-manager)                       |

--- a/plugins/argocd-image-updater
+++ b/plugins/argocd-image-updater
@@ -1,0 +1,1 @@
+repository = https://github.com/thatmlopsguy/asdf-argocd-image-updater.git


### PR DESCRIPTION
## Summary

Description:

- Tool repo URL: https://argocd-image-updater.readthedocs.io/en/stable/
- Plugin repo URL: https://github.com/thatmlopsguy/asdf-argocd-image-updater

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/argocd-image-updater`
- [x] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
