### PR TITLE
feat: Add eks-node-viewer plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | editorconfig-checker          | [gabitchov/asdf-editorconfig-checker](https://github.com/gabitchov/asdf-editorconfig-checker)                     |
 | ejson                         | [cipherstash/asdf-ejson](https://github.com/cipherstash/asdf-ejson)                                               |
 | eksctl                        | [elementalvoid/asdf-eksctl](https://github.com/elementalvoid/asdf-eksctl)                                         |
+| eks-node-viewer               | [haad/asdf-eks-node-viewer](https://github.com/haad/asdf-eks-node-viewer)                                         |
 | elixir-ls                     | [juantascon/asdf-elixir-ls](https://github.com/juantascon/asdf-elixir-ls)                                         |
 | Elasticsearch                 | [asdf-community/asdf-elasticsearch](https://github.com/asdf-community/asdf-elasticsearch)                         |
 | Elixir                        | [asdf-vm/asdf-elixir](https://github.com/asdf-vm/asdf-elixir)                                                     |

--- a/plugins/eks-node-viewer
+++ b/plugins/eks-node-viewer
@@ -1,0 +1,1 @@
+repository = https://github.com/haad/asdf-eks-node-viewer.git


### PR DESCRIPTION
## Summary

Description:

- Tool repo URL:
- Plugin repo URL: https://github.com/haad/asdf-eks-node-viewer

## Checklist

- [ ] Format with `scripts/format.bash`
- [ ] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [ ] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
