### PR TITLE
feat: add gobackup plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | goconvey                      | [therounds-contrib/asdf-goconvey](https://github.com/therounds-contrib/asdf-goconvey)                             |
 | gofumpt                       | [looztra/asdf-gofumpt](https://github.com/looztra/asdf-gofumpt)                                                   |
 | GoHugo                        | [nklmilojevic/asdf-hugo](https://github.com/nklmilojevic/asdf-hugo)                                               |
+| gobackup                      | [0ghny/asdf-gobackup](https://github.com/0ghny/asdf-gobackup)                                                     |
 | gojq                          | [jimmidyson/asdf-gojq](https://github.com/jimmidyson/asdf-gojq)                                                   |
 | golangci-lint                 | [hypnoglow/asdf-golangci-lint](https://github.com/hypnoglow/asdf-golangci-lint)                                   |
 | Go Migrate                    | [joschi/asdf-gomigrate](https://github.com/joschi/asdf-gomigrate)                                                 |

--- a/plugins/gobackup
+++ b/plugins/gobackup
@@ -1,0 +1,1 @@
+repository = https://github.com/0ghny/asdf-gobackup.git


### PR DESCRIPTION
## Summary

Description:

- Tool repo URL: https://github.com/gobackup/gobackup
- Plugin repo URL: https://github.com/0ghny/asdf-gobackup

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
