### PR TITLE
feat: add restish plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -612,6 +612,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | regctl                        | [ORCID/asdf-regctl](https://github.com/ORCID/asdf-regctl)                                                         |
 | regsync                       | [rsrchboy/asdf-regsync](https://github.com/rsrchboy/asdf-regsync)                                                 |
 | restic                        | [xataz/asdf-restic](https://github.com/xataz/asdf-restic)                                                         |
+| restish                       | [polds/asdf-restish](https://github.com/polds/asdf-restish)                                                       |
 | revive                        | [bjw-s/asdf-revive](https://github.com/bjw-s/asdf-revive)                                                         |
 | richgo                        | [paxosglobal/asdf-richgo](https://github.com/paxosglobal/asdf-richgo)                                             |
 | Riff                          | [abinet/asdf-riff](https://github.com/abinet/asdf-riff)                                                           |

--- a/plugins/restish
+++ b/plugins/restish
@@ -1,0 +1,1 @@
+repository = https://github.com/polds/asdf-restish.git


### PR DESCRIPTION
## Summary

Description: Add `restish` plugin. 

> [Restish](https://rest.sh/) is a CLI for interacting with [REST](https://apisyouwonthate.com/blog/rest-and-hypermedia-in-2019)-ish HTTP APIs with some nice features built-in, like always having the latest API resources, fields, and operations available when they go live on the API without needing to install or update anything.

- Tool repo URL:  https://github.com/danielgtaylor/restish
- Plugin repo URL: https://github.com/polds/asdf-restish

## Checklist

- [X] Format with `scripts/format.bash`
- [X] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [X] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
