### PR TITLE
feat: add exercism plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | etcd                          | [particledecay/asdf-etcd](https://github.com/particledecay/asdf-etcd)                                             |
 | Evans                         | [goki90210/asdf-evans](https://github.com/goki90210/asdf-evans)                                                   |
 | exa                           | [nyrst/asdf-exa](https://github.com/nyrst/asdf-exa)                                                               |
+| exercism                      | [bheesham/asdf-exercism](https://gitlab.com/bheesham/asdf-exercism)                                               |
 | eza                           | [lwiechec/asdf-eza](https://github.com/lwiechec/asdf-eza)                                                         |
 | fd                            | [wt0f/asdf-fd](https://gitlab.com/wt0f/asdf-fd)                                                                   |
 | FFmpeg                        | [acj/asdf-ffmpeg](https://github.com/acj/asdf-ffmpeg)                                                             |

--- a/plugins/exercism
+++ b/plugins/exercism
@@ -1,0 +1,1 @@
+repository = https://gitlab.com/bheesham/asdf-exercism.git


### PR DESCRIPTION
## Summary

Description:

- Tool repo URL: https://github.com/exercism/cli
- Plugin repo URL: https://gitlab.com/bheesham/asdf-exercism

## Checklist

- [X] Format with `scripts/format.bash`
- [X] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [X] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
