### PR TITLE
feat: FlutterGen plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | flarectl                      | [ORCID/asdf-flarectl](https://github.com/ORCID/asdf-flarectl)                                                     |
 | flatc                         | [TheOpenDictionary/asdf-flatc](https://github.com/TheOpenDictionary/asdf-flatc)                                   |
 | Flutter                       | [oae/asdf-flutter](https://github.com/oae/asdf-flutter)                                                           |
+| FlutterGen                    | [FlutterGen/asdf-fluttergen](https://github.com/FlutterGen/asdf-fluttergen)                                       |
 | Flux2                         | [tablexi/asdf-flux2](https://github.com/tablexi/asdf-flux2)                                                       |
 | Fluxctl                       | [stefansedich/asdf-fluxctl](https://github.com/stefansedich/asdf-fluxctl)                                         |
 | fly                           | [vmware-tanzu/tanzu-plug-in-for-asdf](https://github.com/vmware-tanzu/tanzu-plug-in-for-asdf)                     |

--- a/plugins/fluttergen
+++ b/plugins/fluttergen
@@ -1,0 +1,1 @@
+repository = https://github.com/FlutterGen/asdf-fluttergen.git


### PR DESCRIPTION
## Summary

Add [FlutterGen](https://github.com/FlutterGen/flutter_gen) plugin.

Description:

- Tool repo URL: https://github.com/FlutterGen/flutter_gen
- Plugin repo URL: https://github.com/FlutterGen/asdf-fluttergen

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
