### PR TITLE
feat: add copier plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | container-diff                | [cgroschupp/asdf-container-diff](https://github.com/cgroschupp/asdf-container-diff)                               |
 | container-structure-test      | [FeryET/asdf-container-structure-test](https://github.com/FeryET/asdf-container-structure-test)                   |
 | cookiecutter                  | [shawon-crosen/asdf-cookiecutter](https://github.com/shawon-crosen/asdf-cookiecutter)                             |
+| Copier                        | [looztra/asdf-copier](https://github.com/looztra/asdf-copier)                                                     |
 | Copper                        | [vladlosev/asdf-copper](https://github.com/vladlosev/asdf-copper)                                                 |
 | Coq                           | [gingerhot/asdf-coq](https://github.com/gingerhot/asdf-coq)                                                       |
 | cosign                        | [wt0f/asdf-cosign](https://gitlab.com/wt0f/asdf-cosign)                                                           |

--- a/plugins/copier
+++ b/plugins/copier
@@ -1,0 +1,1 @@
+repository = https://github.com/looztra/asdf-copier.git


### PR DESCRIPTION
## Summary

Description:

- Tool repo URL: https://github.com/copier-org/copier
- Plugin repo URL: https://github.com/looztra/asdf-copier/

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
