### PR TITLE
feat: add scaffold from hay-kot/scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -627,6 +627,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | rye                           | [Azuki-bar/asdf-rye](https://github.com/Azuki-bar/asdf-rye)                                                       |
 | saml2aws                      | [elementalvoid/asdf-saml2aws](https://github.com/elementalvoid/asdf-saml2aws)                                     |
 | SBT                           | [bram2000/asdf-sbt](https://github.com/bram2000/asdf-sbt)                                                         |
+| scaffold                      | [particledecay/asdf-scaffold](https://github.com/particledecay/asdf-scaffold)                                     |
 | Scala                         | [asdf-community/asdf-scala](https://github.com/asdf-community/asdf-scala)                                         |
 | Scala CLI                     | [asdf-community/asdf-scala-cli](https://github.com/asdf-community/asdf-scala-cli)                                 |
 | scaleway-cli                  | [albarralnunez/asdf-plugin-scaleway-cli](https://github.com/albarralnunez/asdf-plugin-scaleway-cli)               |

--- a/plugins/scaffold
+++ b/plugins/scaffold
@@ -1,0 +1,1 @@
+repository = https://github.com/particledecay/asdf-scaffold.git


### PR DESCRIPTION
## Summary

Description: Add the [scaffold](https://github.com/hay-kot/scaffold) plugin.

- Tool repo URL: [https://github.com/hay-kot/scaffold](https://github.com/hay-kot/scaffold)
- Plugin repo URL: [https://github.com/particledecay/asdf-scaffold](https://github.com/particledecay/asdf-scaffold)

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
