### PR TITLE
fix: replace the asdf-micronaut plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,7 +492,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | Memcached                     | [furkanural/asdf-memcached](https://github.com/furkanural/asdf-memcached)                                         |
 | Mercury                       | [susurri/asdf-mercury](https://github.com/susurri/asdf-mercury)                                                   |
 | Meson                         | [asdf-community/asdf-meson](https://github.com/asdf-community/asdf-meson)                                         |
-| Micronaut                     | [weibemoura/asdf-micronaut](https://github.com/weibemoura/asdf-micronaut)                                         |
+| Micronaut                     | [xafarr/asdf-micronaut](https://github.com/xafarr/asdf-micronaut)                                                 |
 | Mill                          | [asdf-community/asdf-mill](https://github.com/asdf-community/asdf-mill)                                           |
 | mimirtool                     | [asdf-community/asdf-mimirtool](https://github.com/asdf-community/asdf-mimirtool)                                 |
 | minify                        | [axilleas/asdf-minify](https://github.com/axilleas/asdf-minify)                                                   |

--- a/plugins/micronaut
+++ b/plugins/micronaut
@@ -1,1 +1,1 @@
-repository = https://github.com/weibemoura/asdf-micronaut.git
+repository = https://github.com/xafarr/asdf-micronaut.git


### PR DESCRIPTION
## Summary

Description:

- Tool repo URL: [Micronaut](https://micronaut.io/)
- Plugin repo URL: https://github.com/xafarr/asdf-micronaut

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
