### PR TITLE
feat: add spotbugs plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -667,6 +667,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | Spark                         | [joshuaballoch/asdf-spark](https://github.com/joshuaballoch/asdf-spark)                                           |
 | Spectral                      | [vbyrd/asdf-spectral](https://github.com/vbyrd/asdf-spectral)                                                     |
 | Spin                          | [pavloos/asdf-spin](https://github.com/pavloos/asdf-spin)                                                         |
+| spotbugs                      | [jiahuili430/asdf-spotbugs](https://github.com/jiahuili430/asdf-spotbugs)                                         |
 | Spring Boot CLI               | [joschi/asdf-spring-boot](https://github.com/joschi/asdf-spring-boot)                                             |
 | Spruce                        | [woneill/asdf-spruce](https://github.com/woneill/asdf-spruce)                                                     |
 | sqldef                        | [cometkim/asdf-sqldef](https://github.com/cometkim/asdf-sqldef)                                                   |

--- a/plugins/spotbugs
+++ b/plugins/spotbugs
@@ -1,0 +1,1 @@
+repository = https://github.com/jiahuili430/asdf-spotbugs


### PR DESCRIPTION
## Summary

Description: Add `asdf-spotbugs` plugin for `spotbugs`.

- Tool repo URL: https://github.com/spotbugs/spotbugs
- Plugin repo URL: https://github.com/jiahuili430/asdf-spotbugs

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
```bash
$ scripts/test_plugin.bash --file plugins/spotbugs
OK plugins/spotbugs
```
- [x] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
