### PR TITLE
feat: add C3 plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | Buildpack                     | [johnlayton/asdf-buildpack](https://github.com/johnlayton/asdf-buildpack)                                         |
 | Bun                           | [cometkim/asdf-bun](https://github.com/cometkim/asdf-bun)                                                         |
 | Bundler                       | [jonathanmorley/asdf-bundler](https://github.com/jonathanmorley/asdf-bundler)                                     |
+| c3                            | [RobLoach/asdf-c3](https://github.com/RobLoach/asdf-c3)                                                           |
 | Cabal                         | [sestrella/asdf-ghcup](https://github.com/sestrella/asdf-ghcup)                                                   |
 | Caddy                         | [salasrod/asdf-caddy](https://github.com/salasrod/asdf-caddy)                                                     |
 | CalendarSync                  | [FeryET/asdf-calendarsync](https://github.com/FeryET/asdf-calendarsync)                                           |

--- a/plugins/c3
+++ b/plugins/c3
@@ -1,0 +1,1 @@
+repository = https://github.com/RobLoach/asdf-c3.git


### PR DESCRIPTION
## Summary

Description:

- Tool repo URL: https://github.com/c3lang/c3c
- Plugin repo URL: https://github.com/robloach/asdf-c3/

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green

