### PR TITLE
feat: add plugin resticprofile

### DIFF
--- a/README.md
+++ b/README.md
@@ -612,6 +612,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | regctl                        | [ORCID/asdf-regctl](https://github.com/ORCID/asdf-regctl)                                                         |
 | regsync                       | [rsrchboy/asdf-regsync](https://github.com/rsrchboy/asdf-regsync)                                                 |
 | restic                        | [xataz/asdf-restic](https://github.com/xataz/asdf-restic)                                                         |
+| resticprofile                 | [olofvndrhr/asdf-resticprofile](https://github.com/olofvndrhr/asdf-resticprofile)                                 |
 | revive                        | [bjw-s/asdf-revive](https://github.com/bjw-s/asdf-revive)                                                         |
 | richgo                        | [paxosglobal/asdf-richgo](https://github.com/paxosglobal/asdf-richgo)                                             |
 | Riff                          | [abinet/asdf-riff](https://github.com/abinet/asdf-riff)                                                           |

--- a/plugins/resticprofile
+++ b/plugins/resticprofile
@@ -1,0 +1,1 @@
+repository = https://github.com/olofvndrhr/asdf-resticprofile


### PR DESCRIPTION
## Summary

Description:

- Tool repo URL: https://github.com/creativeprojects/resticprofile
- Plugin repo URL: https://github.com/olofvndrhr/asdf-resticprofile

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green


<!-- Thank you for contributing to asdf-plugins! -->
