### PR TITLE
feat: Add Atmos by Cloud Posse

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | asdf-plugin-manager           | [asdf-community/asdf-plugin-manager](https://github.com/asdf-community/asdf-plugin-manager)                       |
 | assh                          | [zekker6/asdf-assh](https://github.com/zekker6/asdf-assh)                                                         |
 | atlas                         | [pbr0ck3r/asdf-atlas](https://github.com/pbr0ck3r/asdf-atlas)                                                     |
+| atmos                         | [cloudposse/atmos](https://github.com/cloudposse/asdf-atmos)                                                      |
 | auto-doc                      | [looztra/asdf-auto-doc](https://github.com/looztra/asdf-auto-doc)                                                 |
 | aws-copilot                   | [NeoHsu/asdf-copilot](https://github.com/NeoHsu/asdf-copilot)                                                     |
 | aws-amplify-cli               | [LozanoMatheus/asdf-aws-amplify-cli](https://github.com/LozanoMatheus/asdf-aws-amplify-cli)                       |

--- a/plugins/atmos
+++ b/plugins/atmos
@@ -1,0 +1,1 @@
+repository = https://github.com/cloudposse/asdf-atmos.git


### PR DESCRIPTION
## Summary

Description:

- Tool repo URL: https://github.com/cloudposse/atmos
- Plugin repo URL: https://github.com/cloudposse/asdf-atmos

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green (see [check](https://github.com/cloudposse/asdf-atmos/actions/runs/10711987313/job/29701643470))
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
