### PR TITLE
chore: remove kubectl-buildkit plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,7 +435,6 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | Kubectl                       | [asdf-community/asdf-kubectl](https://github.com/asdf-community/asdf-kubectl)                                     |
 | kubectl-bindrole              | [looztra/asdf-kubectl-bindrole](https://github.com/looztra/asdf-kubectl-bindrole)                                 |
 | kubectl-convert               | [iul1an/asdf-kubectl-convert](https://github.com/iul1an/asdf-kubectl-convert)                                     |
-| kubectl-buildkit              | [ezcater/asdf-kubectl-buildkit](https://github.com/ezcater/asdf-kubectl-buildkit)                                 |
 | kubectl-kots                  | [ganta/asdf-kubectl-kots](https://github.com/ganta/asdf-kubectl-kots)                                             |
 | kubectx                       | [wt0f/asdf-kubectx](https://gitlab.com/wt0f/asdf-kubectx)                                                         |
 | Kubefedctl                    | [kvokka/asdf-kubefedctl](https://github.com/kvokka/asdf-kubefedctl)                                               |

--- a/plugins/kubectl-buildkit
+++ b/plugins/kubectl-buildkit
@@ -1,1 +1,0 @@
-repository = https://github.com/ezcater/asdf-kubectl-buildkit.git


### PR DESCRIPTION
## Summary

Remove the kubectl-buildkit plugin added in #672.

[kubectl-buildkit](https://github.com/vmware-archive/buildkit-cli-for-kubectl) has been deprecated and moved to the Vmware archive.

ezCater has archived their asdf plugin for the same as a result: https://github.com/ezcater/asdf-kubectl-buildkit/pull/2

## Checklist

- [ ] ~~Format with `scripts/format.bash`~~
- [ ] ~~Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`~~
- [ ] ~~Your plugin CI tests are green~~