### PR TITLE
feat: add dotenvx plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | DOME                          | [jtakakura/asdf-dome](https://github.com/jtakakura/asdf-dome)                                                     |
 | doppler                       | [takutakahashi/asdf-doppler](https://github.com/takutakahashi/asdf-doppler)                                       |
 | dotenv-linter                 | [wesleimp/asdf-dotenv-linter](https://github.com/wesleimp/asdf-dotenv-linter)                                     |
+| dotenvx                       | [jgburet/asdf-dotenvx](https://github.com/jgburet/asdf-dotenvx)                                                   |
 | Dotty                         | [asdf-community/asdf-dotty](https://github.com/asdf-community/asdf-dotty)                                         |
 | dprint                        | [asdf-community/asdf-dprint](https://github.com/asdf-community/asdf-dprint)                                       |
 | Draft                         | [kristoflemmens/asdf-draft](https://github.com/kristoflemmens/asdf-draft)                                         |

--- a/plugins/dotenvx
+++ b/plugins/dotenvx
@@ -1,0 +1,1 @@
+repository = https://github.com/jgburet/asdf-dotenvx.git


### PR DESCRIPTION
## Summary

Description:

- Tool repo URL: https://github.com/dotenvx/dotenvx
- Plugin repo URL: https://github.com/jgburet/asdf-dotenvx

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
