### PR TITLE
feat: Add (pulumi) esc plugin 

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | envsubst                      | [dex4er/asdf-envsubst](https://github.com/dex4er/asdf-envsubst)                                                   |
 | Ephemeral Postgres            | [smashedtoatoms/asdf-ephemeral-postgres](https://github.com/smashedtoatoms/asdf-ephemeral-postgres)               |
 | Erlang                        | [asdf-vm/asdf-erlang](https://github.com/asdf-vm/asdf-erlang)                                                     |
+| esc                           | [fxsalazar/asdf-esc](https://github.com/fxsalazar/asdf-esc)                                                       |
 | esy                           | [asdf-community/asdf-esy](https://github.com/asdf-community/asdf-esy)                                             |
 | etcd                          | [particledecay/asdf-etcd](https://github.com/particledecay/asdf-etcd)                                             |
 | Evans                         | [goki90210/asdf-evans](https://github.com/goki90210/asdf-evans)                                                   |

--- a/plugins/esc
+++ b/plugins/esc
@@ -1,0 +1,1 @@
+repository = https://github.com/fxsalazar/asdf-esc.git


### PR DESCRIPTION
## Summary

Description:

- Tool repo URL: https://github.com/pulumi/esc
- Plugin repo URL: https://github.com/fxsalazar/asdf-esc

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
