### PR TITLE
feat: adding avalanche-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | assh                          | [zekker6/asdf-assh](https://github.com/zekker6/asdf-assh)                                                         |
 | atlas                         | [pbr0ck3r/asdf-atlas](https://github.com/pbr0ck3r/asdf-atlas)                                                     |
 | auto-doc                      | [looztra/asdf-auto-doc](https://github.com/looztra/asdf-auto-doc)                                                 |
+| avalanche                     | [embtools/asdf-avalanche](https://github.com/embtools/asdf-avalanche)                                             |
 | aws-copilot                   | [NeoHsu/asdf-copilot](https://github.com/NeoHsu/asdf-copilot)                                                     |
 | aws-amplify-cli               | [LozanoMatheus/asdf-aws-amplify-cli](https://github.com/LozanoMatheus/asdf-aws-amplify-cli)                       |
 | AWS IAM authenticator         | [zekker6/asdf-aws-iam-authenticator](https://github.com/zekker6/asdf-aws-iam-authenticator)                       |

--- a/plugins/avalanche
+++ b/plugins/avalanche
@@ -1,0 +1,2 @@
+repository = https://github.com/embtools/asdf-avalanche.git
+


### PR DESCRIPTION
## Summary

Description:  Adding the avalanche CLI

- Tool repo URL: https://github.com/ava-labs/avalanche-cli
- Plugin repo URL: https://github.com/embtools/asdf-avalanche

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
