### PR TITLE
fix: update spark plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -696,7 +696,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | Sourcery                      | [younke/asdf-sourcery](https://github.com/younke/asdf-sourcery)                                                   |
 | spacectl                      | [bodgit/asdf-spacectl](https://github.com/bodgit/asdf-spacectl)                                                   |
 | Spago                         | [jrrom/asdf-spago](https://github.com/jrrom/asdf-spago)                                                           |
-| Spark                         | [joshuaballoch/asdf-spark](https://github.com/sudo-black/asdf-spark)                                              |
+| Spark                         | [jeffryang24/asdf-spark](https://github.com/jeffryang24/asdf-spark)                                               |
 | Spectral                      | [vbyrd/asdf-spectral](https://github.com/vbyrd/asdf-spectral)                                                     |
 | Spin                          | [pavloos/asdf-spin](https://github.com/pavloos/asdf-spin)                                                         |
 | spotbugs                      | [jiahuili430/asdf-spotbugs](https://github.com/jiahuili430/asdf-spotbugs)                                         |

--- a/plugins/spark
+++ b/plugins/spark
@@ -1,1 +1,1 @@
-repository = https://github.com/joshuaballoch/asdf-spark.git
+repository = https://github.com/jeffryang24/asdf-spark.git


### PR DESCRIPTION
The other spark plugin repo is broken

## Summary

Description:

Updated the spark plugin repo to a working one.

> Ran `scripts/format.bash` and it didn't report any changes. So I don't know why CI is failing...

- Tool repo URL:
- Plugin repo URL:

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [ ] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
