### PR TITLE
fix: changed gopass repo to new maintainer repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | golangci-lint                 | [hypnoglow/asdf-golangci-lint](https://github.com/hypnoglow/asdf-golangci-lint)                                   |
 | Go Migrate                    | [joschi/asdf-gomigrate](https://github.com/joschi/asdf-gomigrate)                                                 |
 | gomplate                      | [sneakybeaky/asdf-gomplate](https://github.com/sneakybeaky/asdf-gomplate)                                         |
-| Gopass                        | [trallnag/asdf-gopass](https://github.com/trallnag/asdf-gopass)                                                   |
+| Gopass                        | [andrelohmann/asdf-gopass](https://github.com/andrelohmann/asdf-gopass)                                                   |
 | GoReleaser                    | [kforsthoevel/asdf-goreleaser](https://github.com/kforsthoevel/asdf-goreleaser)                                   |
 | Goss                          | [raimon49/asdf-goss](https://github.com/raimon49/asdf-goss)                                                       |
 | GraalVM                       | [asdf-community/asdf-graalvm](https://github.com/asdf-community/asdf-graalvm)                                     |

--- a/plugins/gopass
+++ b/plugins/gopass
@@ -1,1 +1,1 @@
-repository = https://github.com/trallnag/asdf-gopass.git
+repository = https://github.com/andrelohmann/asdf-gopass.git


### PR DESCRIPTION
## Summary

Description:

- Tool repo URL:
- Plugin repo URL:

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->

I forked the gopass plugin from the original plugin repo of https://github.com/trallnag/asdf-gopass and fixed a bug with the architecture selector, as well as updated the dependencies. The repo seems orphaned since 3 years and the original author was not responding to my PR and email contacts. Please merge the new fixed repo, as we need the gopass plugin to be working within a amr based container.