### PR TITLE
feat: add devpod-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | Dep                           | [paxosglobal/asdf-dep](https://github.com/paxosglobal/asdf-dep)                                                   |
 | depot                         | [depot/asdf-depot](https://github.com/depot/asdf-depot)                                                           |
 | Desk                          | [endorama/asdf-desk](https://github.com/endorama/asdf-desk)                                                       |
+| devpod-cli                    | [salemgolemugoo/asdf-devpod-cli](https://github.com/salemgolemugoo/asdf-devpod-cli)                               |
 | DevSpace                      | [NeoHsu/asdf-devspace](https://github.com/NeoHsu/asdf-devspace)                                                   |
 | DevStream                     | [zhenyuanlau/asdf-dtm](https://github.com/zhenyuanlau/asdf-dtm)                                                   |
 | dhall                         | [aaaaninja/asdf-dhall](https://github.com/aaaaninja/asdf-dhall)                                                   |

--- a/plugins/devpod-cli
+++ b/plugins/devpod-cli
@@ -1,0 +1,1 @@
+repository = https://github.com/salemgolemugoo/asdf-devpod-cli.git


### PR DESCRIPTION
## Summary

Description:

- Tool repo URL: https://github.com/loft-sh/devpod
- Plugin repo URL: https://github.com/salemgolemugoo/asdf-devpod-cli

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
