### PR TITLE
feat: add PlanetScale CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -567,6 +567,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | pipx                          | [yozachar/asdf-pipx](https://github.com/yozachar/asdf-pipx)                                                       |
 | pivnet                        | [vmware-tanzu/tanzu-plug-in-for-asdf](https://github.com/vmware-tanzu/tanzu-plug-in-for-asdf)                     |
 | pkl                           | [mise-plugins/asdf-pkl](https://github.com/mise-plugins/asdf-pkl)                                                 |
+| PlantScale CLI                | [kota65535/asdf-planetscale-cli](https://github.com/kota65535/asdf-planetscale-cli) |
 | Please                        | [asdf-community/asdf-please](https://github.com/asdf-community/asdf-please)                                       |
 | Pluto                         | [FairwindsOps/asdf-pluto](https://github.com/FairwindsOps/asdf-pluto)                                             |
 | pnpm                          | [jonathanmorley/asdf-pnpm](https://github.com/jonathanmorley/asdf-pnpm)                                           |

--- a/README.md
+++ b/README.md
@@ -597,7 +597,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | pivnet                        | [vmware-tanzu/tanzu-plug-in-for-asdf](https://github.com/vmware-tanzu/tanzu-plug-in-for-asdf)                     |
 | pixi                          | [pavelzw/pixi](https://github.com/pavelzw/asdf-pixi)                                                              |
 | pkl                           | [mise-plugins/asdf-pkl](https://github.com/mise-plugins/asdf-pkl)                                                 |
-| PlantScale CLI                | [kota65535/asdf-planetscale-cli](https://github.com/kota65535/asdf-planetscale-cli) |
+| PlantScale CLI                | [kota65535/asdf-planetscale-cli](https://github.com/kota65535/asdf-planetscale-cli)                               |
 | Please                        | [asdf-community/asdf-please](https://github.com/asdf-community/asdf-please)                                       |
 | Pluto                         | [FairwindsOps/asdf-pluto](https://github.com/FairwindsOps/asdf-pluto)                                             |
 | pnpm                          | [jonathanmorley/asdf-pnpm](https://github.com/jonathanmorley/asdf-pnpm)                                           |

--- a/plugins/planetscale-cli
+++ b/plugins/planetscale-cli
@@ -1,0 +1,1 @@
+repository = https://github.com/kota65535/asdf-planetscale-cli.git


### PR DESCRIPTION
## Summary

Description:

- Tool repo URL: https://planetscale.com/docs/reference/planetscale-cli
- Plugin repo URL: https://github.com/kota65535/asdf-planetscale-cli.git

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
