### PR TITLE
feat: adding plugin for avalanchego

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | auth0-cli                     | [gunzy83/asdf-auth0-cli](https://github.com/gunzy83/asdf-auth0-cli)                                               |
 | auto-doc                      | [looztra/asdf-auto-doc](https://github.com/looztra/asdf-auto-doc)                                                 |
 | avalanche                     | [embtools/asdf-avalanche](https://github.com/embtools/asdf-avalanche)                                             |
+| avalanchego                   | [embtools/asdf-avalanchego](https://github.com/embtools/asdf-avalanchego)                                         |
 | aws-copilot                   | [NeoHsu/asdf-copilot](https://github.com/NeoHsu/asdf-copilot)                                                     |
 | aws-amplify-cli               | [LozanoMatheus/asdf-aws-amplify-cli](https://github.com/LozanoMatheus/asdf-aws-amplify-cli)                       |
 | AWS IAM authenticator         | [zekker6/asdf-aws-iam-authenticator](https://github.com/zekker6/asdf-aws-iam-authenticator)                       |

--- a/plugins/avalanchego
+++ b/plugins/avalanchego
@@ -1,0 +1,2 @@
+repository = https://github.com/embtools/asdf-avalanchego.git
+


### PR DESCRIPTION
## Summary

Adding plugin for avalanchego, an Avalanche node server

*This differs from the avalanche plugin which is the developer tool, not the server itself*

Description:

- Tool repo URL: https://github.com/ava-labs/avalanchego
- Plugin repo URL: https://github.com/embtools/asdf-avalanchego

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
