### PR TITLE
feat: Add rustic backup plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -661,6 +661,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | ruff                          | [simhem/asdf-ruff](https://github.com/simhem/asdf-ruff)                                                           |
 | Rust                          | [code-lever/asdf-rust](https://github.com/code-lever/asdf-rust)                                                   |
 | rust-analyzer                 | [Xyven1/asdf-rust-analyzer](https://github.com/Xyven1/asdf-rust-analyzer)                                         |
+| rustic                        | [jahands/asdf-rustic](https://github.com/jahands/asdf-rustic)                                                     |
 | rye                           | [Azuki-bar/asdf-rye](https://github.com/Azuki-bar/asdf-rye)                                                       |
 | saml2aws                      | [elementalvoid/asdf-saml2aws](https://github.com/elementalvoid/asdf-saml2aws)                                     |
 | SBT                           | [bram2000/asdf-sbt](https://github.com/bram2000/asdf-sbt)                                                         |

--- a/plugins/rustic
+++ b/plugins/rustic
@@ -1,0 +1,1 @@
+repository = https://github.com/jahands/asdf-rustic.git


### PR DESCRIPTION
## Summary

Description:

- Tool repo URL: https://github.com/rustic-rs/rustic
- Plugin repo URL: https://github.com/jahands/asdf-rustic

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_
  - https://github.com/jahands/asdf-rustic/actions/runs/11326518078

<!-- Thank you for contributing to asdf-plugins! -->
