### PR TITLE
fix: Update grpc health probe

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,7 +345,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | grex                          | [ouest/asdf-grex](https://github.com/ouest/asdf-grex)                                                             |
 | Groovy                        | [weibemoura/asdf-groovy](https://github.com/weibemoura/asdf-groovy)                                               |
 | grpcurl                       | [asdf-community/asdf-grpcurl](https://github.com/asdf-community/asdf-grpcurl)                                     |
-| grpc-health-probe             | [zufardhiyaulhaq/asdf-grpc-health-probe](https://github.com/zufardhiyaulhaq/asdf-grpc-health-probe)               |
+| grpc-health-probe             | [DanieleIsoni/asdf-grpc-health-probe](https://github.com/DanieleIsoni/asdf-grpc-health-probe)                     |
 | grype                         | [poikilotherm/asdf-grype](https://github.com/poikilotherm/asdf-grype)                                             |
 | gum                           | [lwiechec/asdf-gum](https://github.com/lwiechec/asdf-gum)                                                         |
 | gwvault                       | [GoodwayGroup/asdf-gwvault](https://github.com/GoodwayGroup/asdf-gwvault)                                         |

--- a/plugins/grpc-health-probe
+++ b/plugins/grpc-health-probe
@@ -1,1 +1,1 @@
-repository = https://github.com/zufardhiyaulhaq/asdf-grpc-health-probe.git
+repository = https://github.com/DanieleIsoni/asdf-grpc-health-probe.git


### PR DESCRIPTION
## Summary

Description: Since zufardhiyaulhaq/asdf-grpc-health-probe seems to be not maintained anymore, I forked it to fix installation on M* MacBooks

- Tool repo URL: https://github.com/grpc-ecosystem/grpc-health-probe
- Plugin repo URL: https://github.com/DanieleIsoni/asdf-grpc-health-probe

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green

<!-- Thank you for contributing to asdf-plugins! -->
