### PR TITLE
feat: add argc plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | apollo-ios-cli                | [MacPaw/asdf-apollo-ios-cli](https://github.com/MacPaw/asdf-apollo-ios-cli)                                       |
 | Apollo Router                 | [safx/asdf-apollo-router](https://github.com/safx/asdf-apollo-router)                                             |
 | arc                           | [ORCID/asdf-arc](https://github.com/ORCID/asdf-arc)                                                               |
+| argc                          | [rgeraskin/asdf-argc](https://github.com/rgeraskin/asdf-argc)                                                     |
 | argo                          | [sudermanjr/asdf-argo](https://github.com/sudermanjr/asdf-argo)                                                   |
 | argo-rollouts                 | [abatilo/asdf-argo-rollouts](https://github.com/abatilo/asdf-argo-rollouts)                                       |
 | argocd                        | [beardix/asdf-argocd](https://github.com/beardix/asdf-argocd)                                                     |

--- a/plugins/argc
+++ b/plugins/argc
@@ -1,0 +1,1 @@
+repository = https://github.com/rgeraskin/asdf-argc


### PR DESCRIPTION
## Summary

Description:

- Tool repo URL: https://github.com/sigoden/argc
- Plugin repo URL: https://github.com/rgeraskin/asdf-argc

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/argc`
- [x] Your plugin CI tests are green

<!-- Thank you for contributing to asdf-plugins! -->
