### PR TITLE
feat: Add Supabase CLI plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -729,6 +729,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | stripe-cli                    | [offbyone/asdf-stripe](https://github.com/offbyone/asdf-stripe)                                                   |
 | stylua                        | [jc00ke/asdf-stylua](https://github.com/jc00ke/asdf-stylua)                                                       |
 | sui                           | [placeholder-soft/asdf-sui](https://github.com/placeholder-soft/asdf-sui)                                         |
+| supabase-cli                  | [gavinying/asdf-supabase-cli](https://github.com/gavinying/asdf-supabase-cli)                                     |
 | sver                          | [robzr/asdf-sver](https://github.com/robzr/asdf-sver)                                                             |
 | svu                           | [asdf-community/asdf-svu](https://github.com/asdf-community/asdf-svu)                                             |
 | swag                          | [behoof4mind/asdf-swag](https://github.com/behoof4mind/asdf-swag)                                                 |

--- a/plugins/supabase-cli
+++ b/plugins/supabase-cli
@@ -1,0 +1,1 @@
+repository = https://github.com/gavinying/asdf-supabase-cli.git


### PR DESCRIPTION
## Summary

Description:

- Tool repo URL: https://github.com/supabase/cli
- Plugin repo URL: https://github.com/gavinying/asdf-supabase-cli

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/supabase-cli`
- [x] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
