### PR TITLE
feat: add Hermes engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,6 +366,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | helm-docs                     | [sudermanjr/asdf-helm-docs](https://github.com/sudermanjr/asdf-helm-docs)                                         |
 | Helmfile                      | [feniix/asdf-helmfile](https://github.com/feniix/asdf-helmfile)                                                   |
 | Helmsman                      | [luisdavim/asdf-helmsman](https://github.com/luisdavim/asdf-helmsman)                                             |
+| Hermes                        | [cometkim/asdf-hermes](https://github.com/cometkim/asdf-hermes)                                                   |
 | heroku-cli                    | [treilly94/asdf-heroku-cli](https://github.com/treilly94/asdf-heroku-cli)                                         |
 | hey                           | [raimon49/asdf-hey](https://github.com/raimon49/asdf-hey)                                                         |
 | hishtory                      | [asdf-community/asdf-hishtory](https://github.com/asdf-community/asdf-hishtory)                                   |

--- a/plugins/hermes
+++ b/plugins/hermes
@@ -1,0 +1,1 @@
+repository = https://github.com/cometkim/asdf-hermes.git


### PR DESCRIPTION
## Summary

Description: Add plugin for Hermes; the embedded JS engine CLIs

- Tool repo URL: https://github.com/facebook/hermes
- Plugin repo URL: https://github.com/cometkim/asdf-hermes

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
