### PR TITLE
feat: add Binaryen toolchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | bbr-s3-config-validator       | [vmware-tanzu/tanzu-plug-in-for-asdf](https://github.com/vmware-tanzu/tanzu-plug-in-for-asdf)                     |
 | benthos                       | [benthosdev/benthos-asdf](https://github.com/benthosdev/benthos-asdf)                                             |
 | bfs                           | [virtualroot/asdf-bfs](https://github.com/virtualroot/asdf-bfs)                                                   |
+| Binaryen                      | [cometkim/asdf-binaryen](https://github.com/cometkim/asdf-binaryen)                                               |
 | binnacle                      | [Traackr/asdf-binnacle](https://github.com/Traackr/asdf-binnacle)                                                 |
 | Bitwarden                     | [vixus0/asdf-bitwarden](https://github.com/vixus0/asdf-bitwarden)                                                 |
 | bitwarden-secrets-manager     | [asdf-community/asdf-bitwarden-secrets-manager](https://github.com/asdf-community/asdf-bitwarden-secrets-manager) |

--- a/plugins/binaryen
+++ b/plugins/binaryen
@@ -1,0 +1,1 @@
+repository = https://github.com/cometkim/asdf-binaryen.git


### PR DESCRIPTION
## Summary

Description: Add plugin for Binaryen, the WebAssembly toolchain

- Tool repo URL: https://github.com/WebAssembly/binaryen
- Plugin repo URL: https://github.com/cometkim/binaryen

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
