### PR TITLE
feat: add kubectl-oidc_login plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,6 +461,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | kubectl-bindrole              | [looztra/asdf-kubectl-bindrole](https://github.com/looztra/asdf-kubectl-bindrole)                                 |
 | kubectl-convert               | [iul1an/asdf-kubectl-convert](https://github.com/iul1an/asdf-kubectl-convert)                                     |
 | kubectl-kots                  | [ganta/asdf-kubectl-kots](https://github.com/ganta/asdf-kubectl-kots)                                             |
+| kubectl-oidc_login            | [ezcater/asdf-kubectl-oidc_login](https://github.com/ezcater/asdf-kubectl-oidc_login)                             |
 | kubectx                       | [wt0f/asdf-kubectx](https://gitlab.com/wt0f/asdf-kubectx)                                                         |
 | Kubefedctl                    | [kvokka/asdf-kubefedctl](https://github.com/kvokka/asdf-kubefedctl)                                               |
 | Kubefirst                     | [Claywd/asdf-kubefirst](https://github.com/Claywd/asdf-kubefirst)                                                 |

--- a/plugins/kubectl-oidc_login
+++ b/plugins/kubectl-oidc_login
@@ -1,0 +1,1 @@
+repository = https://github.com/ezcater/asdf-kubectl-oidc_login.git


### PR DESCRIPTION
## Summary

Adds the `kubectl-oidc_login` plugin to the repository.

Note: the tool being installed calls itself `kubelogin` but, due to the name being overloaded (e.g. another plugin in this repo), it is installed as `kubectl-oidc_login` ([reference](https://github.com/int128/kubelogin?tab=readme-ov-file#setup)). This is why this name was chosen for the plugin.

Description:

- Tool repo URL: [int128/kubelogin](https://github.com/int128/kubelogin)
- Plugin repo URL: [ezcater/asdf-kubectl-oidc_login](https://github.com/ezcater/asdf-kubectl-oidc_login)

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
