### PR TITLE
feat: add hcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,6 +358,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | Haxe                          | [asdf-community/asdf-haxe](https://github.com/asdf-community/asdf-haxe)                                           |
 | hcl2json                      | [dex4er/asdf-hcl2json](https://github.com/dex4er/asdf-hcl2json)                                                   |
 | hcloud                        | [chessmango/asdf-hcloud](https://github.com/chessmango/asdf-hcloud)                                               |
+| hcp                           | [asdf-community/asdf-hashicorp](https://github.com/asdf-community/asdf-hashicorp)                                 |
 | Helix Editor                  | [CSergienko/asdf-helix](https://github.com/CSergienko/asdf-helix)                                                 |
 | Helm                          | [Antiarchitect/asdf-helm](https://github.com/Antiarchitect/asdf-helm)                                             |
 | Helm Chart Releaser           | [Antiarchitect/asdf-helm-cr](https://github.com/Antiarchitect/asdf-helm-cr)                                       |

--- a/plugins/hcp
+++ b/plugins/hcp
@@ -1,0 +1,1 @@
+repository = https://github.com/asdf-community/asdf-hashicorp.git


### PR DESCRIPTION
## Summary

Description:

Adds `hcp` via the asdf-hashicorp plugin.

- Tool repo URL: https://github.com/hashicorp/hcp
- Plugin repo URL: https://github.com/asdf-community/asdf-hashicorp

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
