### PR TITLE
feat: add lq asdf plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,6 +497,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | Litestream                    | [threkk/asdf-litestream](https://github.com/threkk/asdf-litestream)                                               |
 | Logtalk                       | [LogtalkDotOrg/asdf-logtalk](https://github.com/LogtalkDotOrg/asdf-logtalk)                                       |
 | Loki-Logcli                   | [comdotlinux/asdf-loki-logcli](https://github.com/comdotlinux/asdf-loki-logcli)                                   |
+| lq                            | [jylenhof/asdf-lq](https://github.com/jylenhof/asdf-lq)                                                           |
 | ls-lint                       | [ameausoone/asdf-ls-lint](https://github.com/ameausoone/asdf-ls-lint)                                             |
 | Lua                           | [Stratus3D/asdf-lua](https://github.com/Stratus3D/asdf-lua)                                                       |
 | LuaJIT                        | [smashedtoatoms/asdf-luaJIT](https://github.com/smashedtoatoms/asdf-luaJIT)                                       |

--- a/plugins/lq
+++ b/plugins/lq
@@ -1,0 +1,1 @@
+repository = https://github.com/jylenhof/asdf-lq.git


### PR DESCRIPTION
## Summary

Description:

- Tool repo URL: https://github.com/clux/lq
- Plugin repo URL: https://github.com/jylenhof/asdf-lq

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
