### PR TITLE
feat: add dst

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | Draft                         | [kristoflemmens/asdf-draft](https://github.com/kristoflemmens/asdf-draft)                                         |
 | Driftctl                      | [nlamirault/asdf-driftctl](https://github.com/nlamirault/asdf-driftctl)                                           |
 | drone                         | [virtualstaticvoid/asdf-drone](https://github.com/virtualstaticvoid/asdf-drone)                                   |
+| dst                           | [datasprayio/asdf-dst](https://github.com/datasprayio/asdf-dst)                                                   |
 | dt                            | [so-dang-cool/asdf-dt](https://github.com/so-dang-cool/asdf-dt)                                                   |
 | duf                           | [NeoHsu/asdf-duf](https://github.com/NeoHsu/asdf-duf)                                                             |
 | dust                          | [looztra/asdf-dust](https://github.com/looztra/asdf-dust)                                                         |

--- a/plugins/dst
+++ b/plugins/dst
@@ -1,0 +1,1 @@
+repository = https://github.com/datasprayio/asdf-dst.git


### PR DESCRIPTION
## Summary

Description: DataSpray is a platform for streaming data and security monitoring. The `dst` CLI tool is used for managing stream processor code used by the streaming platform. It allows creating boilerplate code, building, testing and deploying to the DataSpray platform.

- Tool repo URL: https://github.com/datasprayio/dataspray
- Plugin repo URL: https://github.com/datasprayio/asdf-dst

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
