### PR TITLE
feat: add cairo-profiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | c3                            | [RobLoach/asdf-c3](https://github.com/RobLoach/asdf-c3)                                                           |
 | Cabal                         | [sestrella/asdf-ghcup](https://github.com/sestrella/asdf-ghcup)                                                   |
 | Caddy                         | [salasrod/asdf-caddy](https://github.com/salasrod/asdf-caddy)                                                     |
+| cairo-profiler                | [software-mansion/asdf-cairo-profiler](https://github.com/software-mansion/asdf-cairo-profiler)                   |
 | CalendarSync                  | [FeryET/asdf-calendarsync](https://github.com/FeryET/asdf-calendarsync)                                           |
 | Calicoctl                     | [FairwindsOps/asdf-calicoctl](https://github.com/FairwindsOps/asdf-calicoctl)                                     |
 | Camunda Modeler               | [barmac/asdf-camunda-modeler](https://github.com/barmac/asdf-camunda-modeler)                                     |

--- a/plugins/cairo-profiler
+++ b/plugins/cairo-profiler
@@ -1,0 +1,1 @@
+repository = https://github.com/software-mansion/asdf-cairo-profiler


### PR DESCRIPTION
## Summary

Description:

- Tool repo URL: https://github.com/software-mansion/cairo-profiler
- Plugin repo URL: https://github.com/software-mansion/asdf-cairo-profiler

## Checklist

- [X] Format with `scripts/format.bash`
- [X] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [X] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
