### PR TITLE
feat: Add signal-cli to plugins list

### DIFF
--- a/README.md
+++ b/README.md
@@ -687,6 +687,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | Shellspec                     | [poikilotherm/asdf-shellspec](https://github.com/poikilotherm/asdf-shellspec)                                     |
 | Shfmt                         | [luizm/asdf-shfmt](https://github.com/luizm/asdf-shfmt)                                                           |
 | Shorebird                     | [valian-ca/asdf-shorebird](https://github.com/valian-ca/asdf-shorebird)                                           |
+| signal-cli                    | [ehsash/asdf-signal-cli](https://github.com/ehsash/asdf-signal-cli)                                               |
 | Sinker                        | [elementalvoid/asdf-sinker](https://github.com/elementalvoid/asdf-sinker)                                         |
 | Skaffold                      | [nklmilojevic/asdf-skaffold](https://github.com/nklmilojevic/asdf-skaffold)                                       |
 | skate                         | [chessmango/asdf-skate](https://github.com/chessmango/asdf-skate)                                                 |

--- a/plugins/signal-cli
+++ b/plugins/signal-cli
@@ -1,0 +1,1 @@
+repository = https://github.com/ehsash/asdf-signal-cli.git


### PR DESCRIPTION
## Summary

Description:

- Tool repo URL: https://github.com/AsamK/signal-cli
- Plugin repo URL: https://github.com/ehsash/asdf-signal-cli

## Checklist

- [X] Format with `scripts/format.bash`
- [X] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [X] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
