### PR TITLE
feat: Add asdf-qsv plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -627,6 +627,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | Purty                         | [nsaunders/asdf-purty](https://github.com/nsaunders/asdf-purty)                                                   |
 | Python                        | [danhper/asdf-python](https://github.com/danhper/asdf-python)                                                     |
 | q                             | [moritz-makandra/asdf-plugin-qdns](https://github.com/moritz-makandra/asdf-plugin-qdns)                           |
+| qsv                           | [vjda/asdf-qsv](https://github.com/vjda/asdf-qsv)                                                                 |
 | Quarkus CLI                   | [asdf-community/asdf-quarkus](https://github.com/asdf-community/asdf-quarkus)                                     |
 | R                             | [asdf-community/asdf-r](https://github.com/asdf-community/asdf-r)                                                 |
 | RabbitMQ                      | [w-sanches/asdf-rabbitmq](https://github.com/w-sanches/asdf-rabbitmq)                                             |

--- a/plugins/qsv
+++ b/plugins/qsv
@@ -1,0 +1,1 @@
+repository = https://github.com/vjda/asdf-qsv.git


### PR DESCRIPTION
## Summary

Add plugin for qsv tool, a CLI to work with large datasets in csv files.

Description:

- Tool repo URL: https://qsv.dathere.com/
- Plugin repo URL: https://github.com/vjda/asdf-qsv

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
