### PR TITLE
feat: Adds plugin for alire

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | air                           | [pdemagny/asdf-air](https://github.com/pdemagny/asdf-air)                                                         |
 | aks-engine                    | [robsonpeixoto/asdf-aks-engine](https://github.com/robsonpeixoto/asdf-aks-engine)                                 |
 | alias                         | [andrewthauer/asdf-alias](https://github.com/andrewthauer/asdf-alias)                                             |
+| alire                         | [NyanHelsing/asdf-alire](https://github.com/NyanHelsing/asdf-alire)                                               |
 | allure                        | [comdotlinux/asdf-allure](https://github.com/comdotlinux/asdf-allure)                                             |
 | alp                           | [asdf-community/asdf-alp](https://github.com/asdf-community/asdf-alp)                                             |
 | amass                         | [dhoeric/asdf-amass](https://github.com/dhoeric/asdf-amass)                                                       |

--- a/plugins/alire
+++ b/plugins/alire
@@ -1,0 +1,1 @@
+repository = https://github.com/NyanHelsing/asdf-alire.git


### PR DESCRIPTION
## Summary

Description:

- Tool repo URL: https://github.com/alire-project/alire
- Plugin repo URL: https://github.com/NyanHelsing/asdf-alire

## Checklist

- [ ] Format with `scripts/format.bash`
- [ ] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [ ] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
