### PR TITLE
feat: add gruntwork boilerplate

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | binnacle                      | [Traackr/asdf-binnacle](https://github.com/Traackr/asdf-binnacle)                                                 |
 | Bitwarden                     | [vixus0/asdf-bitwarden](https://github.com/vixus0/asdf-bitwarden)                                                 |
 | bitwarden-secrets-manager     | [asdf-community/asdf-bitwarden-secrets-manager](https://github.com/asdf-community/asdf-bitwarden-secrets-manager) |
+| boilerplate                   | [gruntwork-io/asdf-boilerpalte](https://github.com/gruntwork-io/asdf-boilerplate)                                 |
 | Bombardier                    | [NeoHsu/asdf-bombardier](https://github.com/NeoHsu/asdf-bombardier)                                               |
 | borg                          | [lwiechec/asdf-borg](https://github.com/lwiechec/asdf-borg)                                                       |
 | bosh                          | [vmware-tanzu/tanzu-plug-in-for-asdf](https://github.com/vmware-tanzu/tanzu-plug-in-for-asdf)                     |

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | binnacle                      | [Traackr/asdf-binnacle](https://github.com/Traackr/asdf-binnacle)                                                 |
 | Bitwarden                     | [vixus0/asdf-bitwarden](https://github.com/vixus0/asdf-bitwarden)                                                 |
 | bitwarden-secrets-manager     | [asdf-community/asdf-bitwarden-secrets-manager](https://github.com/asdf-community/asdf-bitwarden-secrets-manager) |
-| boilerplate                   | [gruntwork-io/asdf-boilerpalte](https://github.com/gruntwork-io/asdf-boilerplate)                                 |
+| boilerplate                   | [gruntwork-io/asdf-boilerplate](https://github.com/gruntwork-io/asdf-boilerplate)                                 |
 | Bombardier                    | [NeoHsu/asdf-bombardier](https://github.com/NeoHsu/asdf-bombardier)                                               |
 | borg                          | [lwiechec/asdf-borg](https://github.com/lwiechec/asdf-borg)                                                       |
 | bosh                          | [vmware-tanzu/tanzu-plug-in-for-asdf](https://github.com/vmware-tanzu/tanzu-plug-in-for-asdf)                     |

--- a/plugins/boilerplate
+++ b/plugins/boilerplate
@@ -1,0 +1,1 @@
+repository = https://github.com/gruntwork-io/asdf-boilerplate


### PR DESCRIPTION
## Summary

Description:

- Tool repo URL: https://github.com/gruntwork-io/boilerplate
- Plugin repo URL: https://github.com/gruntwork-io/asdf-boilerplate

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
