### PR TITLE
fix: replace calicoctl plugin with its upstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | cairo-coverage                | [software-mansion/asdf-cairo-coverage](https://github.com/software-mansion/asdf-cairo-coverage)                   |
 | cairo-profiler                | [software-mansion/asdf-cairo-profiler](https://github.com/software-mansion/asdf-cairo-profiler)                   |
 | CalendarSync                  | [FeryET/asdf-calendarsync](https://github.com/FeryET/asdf-calendarsync)                                           |
-| Calicoctl                     | [FairwindsOps/asdf-calicoctl](https://github.com/FairwindsOps/asdf-calicoctl)                                     |
+| calicoctl                     | [teejaded/asdf-calicoctl](https://github.com/teejaded/asdf-calicoctl)                                             |
 | Camunda Modeler               | [barmac/asdf-camunda-modeler](https://github.com/barmac/asdf-camunda-modeler)                                     |
 | cargo-make                    | [mise-plugins/asdf-cargo-make](https://github.com/mise-plugins/asdf-cargo-make)                                   |
 | Carp                          | [susurri/asdf-carp](https://github.com/susurri/asdf-carp)                                                         |

--- a/plugins/calicoctl
+++ b/plugins/calicoctl
@@ -1,1 +1,1 @@
-repository = https://github.com/TheCubicleJockey/asdf-calicoctl.git
+repository = https://github.com/teejaded/asdf-calicoctl.git


### PR DESCRIPTION
## Summary

Description: Replace the currently provided `calicoctl` plugin with the upstream repository it was forked from. The currently used repository does not currently work, but the upstream repository works as expected.

- Tool repo URL: https://github.com/projectcalico/calico/
- Plugin repo URL: https://github.com/teejaded/asdf-calicoctl

## Checklist

- [X] Format with `scripts/format.bash`
- [X] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [X] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
