### PR TITLE
feat: update repository URLs for bat and tmux plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | balena-cli                    | [boatkit-io/asdf-balena-cli](https://github.com/boatkit-io/asdf-balena-cli)                                       |
 | bashbot                       | [mathew-fleisch/asdf-bashbot](https://github.com/mathew-fleisch/asdf-bashbot)                                     |
 | bashly                        | [pcrockett/asdf-bashly](https://github.com/pcrockett/asdf-bashly)                                                 |
-| bat                           | [wt0f/asdf-bat](https://gitlab.com/wt0f/asdf-bat)                                                                 |
+| bat                           | [pauloedurezende/asdf-bat](https://github.com/pauloedurezende/asdf-bat)                                           |
 | bat-extras                    | [vhdirk/asdf-bat-extras](https://github.com/vhdirk/asdf-bat-extras)                                               |
 | Batect                        | [johnlayton/asdf-batect](https://github.com/johnlayton/asdf-batect)                                               |
 | Bats (Bash unittest)          | [timgluz/asdf-bats](https://github.com/timgluz/asdf-bats)                                                         |
@@ -805,7 +805,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | Tinytex                       | [Fbrisset/asdf-tinytex](https://github.com/Fbrisset/asdf-tinytex)                                                 |
 | Titan                         | [gabitchov/asdf-titan](https://github.com/gabitchov/asdf-titan)                                                   |
 | tlsg-cli                      | [0ghny/asdf-tlsgcli](https://github.com/0ghny/asdf-tlsgcli)                                                       |
-| Tmux                          | [aphecetche/asdf-tmux](https://github.com/aphecetche/asdf-tmux)                                                   |
+| Tmux                          | [pauloedurezende/asdf-tmux](https://github.com/pauloedurezende/asdf-tmux)                                         |
 | Tokei                         | [gasuketsu/asdf-tokei](https://github.com/gasuketsu/asdf-tokei)                                                   |
 | tomcat                        | [asdf-community/asdf-tomcat](https://github.com/asdf-community/asdf-tomcat)                                       |
 | tonnage                       | [elementalvoid/asdf-tonnage](https://github.com/elementalvoid/asdf-tonnage)                                       |

--- a/plugins/bat
+++ b/plugins/bat
@@ -1,1 +1,1 @@
-repository = https://gitlab.com/wt0f/asdf-bat.git
+repository = https://github.com/pauloedurezende/asdf-bat.git

--- a/plugins/tmux
+++ b/plugins/tmux
@@ -1,1 +1,1 @@
-repository = https://github.com/aphecetche/asdf-tmux.git
+repository = https://github.com/pauloedurezende/asdf-tmux.git


### PR DESCRIPTION
## Summary

### tmux
A terminal multiplexer: it enables a number of terminals to be created, accessed, and controlled from a single screen.

- Tool repo URL: https://github.com/tmux/tmux
- Plugin repo URL: https://github.com/pauloedurezende/asdf-tmux

### bat
A cat(1) clone with syntax highlighting and Git integration.

- Tool repo URL: https://github.com/sharkdp/bat
- Plugin repo URL: https://github.com/pauloedurezende/asdf-bat

## Checklist

- [X] Format with `scripts/format.bash`
- [X] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [X] Your plugin CI tests are green

## Motivations for Changing Plugin Links

This pull request proposes changing the existing plugin links for `tmux` and `bat` in the `asdf-plugins` repository. These changes are necessary due to issues identified with the current installations of the plugins:

1. **`bat` Plugin:**
   - The `bat` plugin is unable to install correctly because it cannot find the correct download URL. This issue prevents users from installing and using `bat` effectively through `asdf`.

2. **`tmux` Plugin:**
   - The `tmux` plugin faces difficulties in being installed because it cannot build from the current repository. This limits user's ability to integrate `tmux` into their development environments using `asdf`.

To address these issues, I have created new repositories specifically for `asdf` that fix the aforementioned problems. The intention is to set these new repositories as the default in `asdf-plugins`, ensuring a smoother and more functional installation experience for all users.

These modifications are essential to improve user experience and ensure that `tmux` and `bat` can be installed and used without complications. I appreciate the consideration of this pull request and am available for any questions or necessary adjustments.