### PR TITLE
feat: Add ffizer plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | eza                           | [lwiechec/asdf-eza](https://github.com/lwiechec/asdf-eza)                                                         |
 | fastlane                      | [mollyIV/asdf-fastlane](https://github.com/mollyIV/asdf-fastlane)                                                 |
 | fd                            | [wt0f/asdf-fd](https://gitlab.com/wt0f/asdf-fd)                                                                   |
+| ffizer                        | [ffizer/asdf-ffizer](https://github.com/ffizer/asdf-ffizer)                                                       |
 | FFmpeg                        | [acj/asdf-ffmpeg](https://github.com/acj/asdf-ffmpeg)                                                             |
 | figma-export                  | [younke/asdf-figma-export](https://github.com/younke/asdf-figma-export)                                           |
 | fillin                        | [ouest/asdf-fillin](https://github.com/ouest/asdf-fillin)                                                         |

--- a/plugins/ffizer
+++ b/plugins/ffizer
@@ -1,0 +1,1 @@
+repository = https://github.com/ffizer/asdf-ffizer.git


### PR DESCRIPTION
## Summary

Description:

- Tool repo URL: https://github.com/ffizer/ffizer
- Plugin repo URL: https://github.com/ffizer/asdf-ffizer

## Checklist

- [X] Format with `scripts/format.bash`
- [X] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [ ] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
