### PR TITLE
feat: Add Yasm plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -848,6 +848,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | yamllint                      | [ericcornelissen/asdf-yamllint](https://github.com/ericcornelissen/asdf-yamllint)                                 |
 | yamlscript                    | [FeryET/asdf-yamlscript](https://github.com/FeryET/asdf-yamlscript)                                               |
 | Yarn                          | [twuni/asdf-yarn](https://github.com/twuni/asdf-yarn)                                                             |
+| Yasm                          | [kkHAIKE/asdf-yasm](https://github.com/kkHAIKE/asdf-yasm/)                                                        |
 | yay                           | [aaaaninja/asdf-yay](https://github.com/aaaaninja/asdf-yay)                                                       |
 | Yor                           | [ordinaryexperts/asdf-yor](https://github.com/ordinaryexperts/asdf-yor)                                           |
 | youtube-dl                    | [iul1an/asdf-youtube-dl](https://github.com/iul1an/asdf-youtube-dl)                                               |

--- a/README.md
+++ b/README.md
@@ -848,7 +848,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | yamllint                      | [ericcornelissen/asdf-yamllint](https://github.com/ericcornelissen/asdf-yamllint)                                 |
 | yamlscript                    | [FeryET/asdf-yamlscript](https://github.com/FeryET/asdf-yamlscript)                                               |
 | Yarn                          | [twuni/asdf-yarn](https://github.com/twuni/asdf-yarn)                                                             |
-| Yasm                          | [kkHAIKE/asdf-yasm](https://github.com/kkHAIKE/asdf-yasm/)                                                        |
+| Yasm                          | [kkHAIKE/asdf-yasm](https://github.com/kkHAIKE/asdf-yasm)                                                         |
 | yay                           | [aaaaninja/asdf-yay](https://github.com/aaaaninja/asdf-yay)                                                       |
 | Yor                           | [ordinaryexperts/asdf-yor](https://github.com/ordinaryexperts/asdf-yor)                                           |
 | youtube-dl                    | [iul1an/asdf-youtube-dl](https://github.com/iul1an/asdf-youtube-dl)                                               |

--- a/plugins/yasm
+++ b/plugins/yasm
@@ -1,0 +1,1 @@
+repository = https://github.com/kkHAIKE/asdf-yasm.git


### PR DESCRIPTION
## Summary

Description:

- Tool repo URL: https://github.com/yasm/yasm
- Plugin repo URL: https://github.com/kkHAIKE/asdf-plugins

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [ ] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
