### PR TITLE
feat: add roswell plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -672,6 +672,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | ripgrep                       | [wt0f/asdf-ripgrep](https://gitlab.com/wt0f/asdf-ripgrep)                                                         |
 | RKE                           | [particledecay/asdf-rke](https://github.com/particledecay/asdf-rke)                                               |
 | rome                          | [kichiemon/asdf-rome](https://github.com/kichiemon/asdf-rome)                                                     |
+| Roswell                       | [troydm/asdf-roswell](https://github.com/troydm/asdf-roswell)                                                     |
 | Redpanda RPK                  | [jleight/asdf-rpk](https://github.com/jleight/asdf-rpk)                                                           |
 | rstash                        | [carlduevel/asdf-rstash](https://github.com/carlduevel/asdf-rstash)                                               |
 | rlwrap                        | [asdf-community/asdf-rlwrap](https://github.com/asdf-community/asdf-rlwrap)                                       |

--- a/plugins/roswell
+++ b/plugins/roswell
@@ -1,0 +1,1 @@
+repository = https://github.com/troydm/asdf-roswell.git


### PR DESCRIPTION
## Summary

Description:

- Tool repo URL: https://github.com/roswell/roswell
- Plugin repo URL: https://github.com/troydm/asdf-roswell

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
