### PR TITLE
feat: add omnictl plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -584,6 +584,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | Okteto                        | [BradenM/asdf-okteto](https://github.com/BradenM/asdf-okteto)                                                     |
 | ollama                        | [virtualstaticvoid/asdf-ollama](https://github.com/virtualstaticvoid/asdf-ollama)                                 |
 | om                            | [vmware-tanzu/tanzu-plug-in-for-asdf](https://github.com/vmware-tanzu/tanzu-plug-in-for-asdf)                     |
+| omnictl                       | [alongwill/asdf-omnictl](https://github.com/alongwill/asdf-omnictl)                                               |
 | Onyx                          | [jtakakura/asdf-onyx](https://github.com/jtakakura/asdf-onyx)                                                     |
 | OPA                           | [tochukwuvictor/asdf-opa](https://github.com/tochukwuvictor/asdf-opa)                                             |
 | Opam                          | [asdf-community/asdf-opam](https://github.com/asdf-community/asdf-opam)                                           |

--- a/plugins/omnictl
+++ b/plugins/omnictl
@@ -1,0 +1,1 @@
+repository = https://github.com/alongwill/asdf-omnictl.git


### PR DESCRIPTION
## Summary

Description:

- Tool repo URL: https://github.com/siderolabs/omni
- Plugin repo URL: https://github.com/alongwill/asdf-omnictl

`omnictl` is use for managing kubernetes clusters of Talos Linux nodes.
Related: #788.

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
