### PR TITLE
feat: Add clang-tools plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | Chromedriver                  | [schinckel/asdf-chromedriver](https://github.com/schinckel/asdf-chromedriver)                                     |
 | cilium-cli                    | [carnei-ro/asdf-cilium-cli](https://github.com/carnei-ro/asdf-cilium-cli)                                         |
 | cilium-hubble                 | [NitriKx/asdf-cilium-hubble](https://github.com/NitriKx/asdf-cilium-hubble)                                       |
+| clang-tools                   | [cpp-linter/asdf-clang-tools](https://github.com/cpp-linter/asdf-clang-tools)                                     |
 | Clarinet                      | [alexgo-io/asdf-clarinet](https://github.com/alexgo-io/asdf-clarinet)                                             |
 | clj-kondo                     | [rynkowsg/asdf-clj-kondo](https://github.com/rynkowsg/asdf-clj-kondo)                                             |
 | cljstyle                      | [abogoyavlensky/asdf-cljstyle](https://github.com/abogoyavlensky/asdf-cljstyle)                                   |

--- a/plugins/clang-tools
+++ b/plugins/clang-tools
@@ -1,0 +1,1 @@
+repository = https://github.com/cpp-linter/asdf-clang-tools.git


### PR DESCRIPTION
## Summary

Description:

- Tool repo URL: https://github.com/cpp-linter/clang-tools-static-binaries
- Plugin repo URL: https://github.com/cpp-linter/asdf-clang-tools

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
