### PR TITLE
feat: add sqlcmd plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -730,6 +730,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | Spring Boot CLI               | [joschi/asdf-spring-boot](https://github.com/joschi/asdf-spring-boot)                                             |
 | Spruce                        | [woneill/asdf-spruce](https://github.com/woneill/asdf-spruce)                                                     |
 | sqlc                          | [dylanrayboss/asdf-sqlc](https://github.com/dylanrayboss/asdf-sqlc)                                               |
+| sqlcmd                        | [ahyalfan/asdf-sqlcmd](https://github.com/ahyalfan/asdf-sqlcmd)                                                   |
 | sqldef                        | [cometkim/asdf-sqldef](https://github.com/cometkim/asdf-sqldef)                                                   |
 | SQLite                        | [cLupus/asdf-sqlite](https://github.com/cLupus/asdf-sqlite)                                                       |
 | sshuttle                      | [xanmanning/asdf-sshuttle](https://github.com/xanmanning/asdf-sshuttle)                                           |

--- a/plugins/sqlcmd
+++ b/plugins/sqlcmd
@@ -1,0 +1,1 @@
+repository = https://github.com/ahyalfan/asdf-sqlcmd.git


### PR DESCRIPTION
## Summary

Description:

- Tool repo URL: https://github.com/microsoft/go-sqlcmd
- Plugin repo URL: https://github.com/ahyalfan/asdf-sqlcmd

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
