### PR TITLE
feat: Add voyager plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -842,7 +842,8 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | velad                         | [pdemagny/asdf-velad](https://github.com/pdemagny/asdf-velad)                                                     |
 | vhs                           | [chessmango/asdf-vhs](https://github.com/chessmango/asdf-vhs)                                                     |
 | Viddy                         | [ryodocx/asdf-viddy](https://github.com/ryodocx/asdf-viddy)                                                       |
-| Vim                           | [tsuyoshicho/asdf-vim](https://github.com/tsuyoshicho/asdf-vim)                                                   |
+| Vim                           | [tsuyoshicho/asdf-vim](https://github.com/tsuyoshicho/asdf-vim)
+| voyager                       | [NethermindEth/asdf-voyager-verifier](https://github.com/NethermindEth/asdf-voyager-verifier)                     |                                                   |
 | vlt                           | [asdf-community/asdf-hashicorp](https://github.com/asdf-community/asdf-hashicorp)                                 |
 | vultr-cli                     | [ikuradon/asdf-vultr-cli](https://github.com/ikuradon/asdf-vultr-cli)                                             |
 | watchexec                     | [nyrst/asdf-watchexec](https://github.com/nyrst/asdf-watchexec)                                                   |

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 ## Plugin List
 
 | Tool / Language               | Plugin Repository                                                                                                 |
-| :---------------------------- | :---------------------------------------------------------------------------------------------------------------- |
+| :---------------------------- | :---------------------------------------------------------------------------------------------------------------- | --- |
 | .Net                          | [hensou/asdf-dotnet](https://github.com/hensou/asdf-dotnet)                                                       |
 | .Net Core                     | [emersonsoares/asdf-dotnet-core](https://github.com/emersonsoares/asdf-dotnet-core)                               |
 | 1password-cli                 | [NeoHsu/asdf-1password-cli](https://github.com/NeoHsu/asdf-1password-cli)                                         |
@@ -843,6 +843,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | vhs                           | [chessmango/asdf-vhs](https://github.com/chessmango/asdf-vhs)                                                     |
 | Viddy                         | [ryodocx/asdf-viddy](https://github.com/ryodocx/asdf-viddy)                                                       |
 | Vim                           | [tsuyoshicho/asdf-vim](https://github.com/tsuyoshicho/asdf-vim)                                                   |
+| voyager                       | [NethermindEth/asdf-voyager-verifier](https://github.com/NethermindEth/asdf-voyager-verifier)                     |     |
 | vlt                           | [asdf-community/asdf-hashicorp](https://github.com/asdf-community/asdf-hashicorp)                                 |
 | vultr-cli                     | [ikuradon/asdf-vultr-cli](https://github.com/ikuradon/asdf-vultr-cli)                                             |
 | watchexec                     | [nyrst/asdf-watchexec](https://github.com/nyrst/asdf-watchexec)                                                   |

--- a/README.md
+++ b/README.md
@@ -842,8 +842,8 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | velad                         | [pdemagny/asdf-velad](https://github.com/pdemagny/asdf-velad)                                                     |
 | vhs                           | [chessmango/asdf-vhs](https://github.com/chessmango/asdf-vhs)                                                     |
 | Viddy                         | [ryodocx/asdf-viddy](https://github.com/ryodocx/asdf-viddy)                                                       |
-| Vim                           | [tsuyoshicho/asdf-vim](https://github.com/tsuyoshicho/asdf-vim)
-| voyager                       | [NethermindEth/asdf-voyager-verifier](https://github.com/NethermindEth/asdf-voyager-verifier)                     |                                                   |
+| Vim                           | [tsuyoshicho/asdf-vim](https://github.com/tsuyoshicho/asdf-vim)                                                   |
+| voyager                       | [NethermindEth/asdf-voyager-verifier](https://github.com/NethermindEth/asdf-voyager-verifier)                     |     |
 | vlt                           | [asdf-community/asdf-hashicorp](https://github.com/asdf-community/asdf-hashicorp)                                 |
 | vultr-cli                     | [ikuradon/asdf-vultr-cli](https://github.com/ikuradon/asdf-vultr-cli)                                             |
 | watchexec                     | [nyrst/asdf-watchexec](https://github.com/nyrst/asdf-watchexec)                                                   |

--- a/plugins/voyager
+++ b/plugins/voyager
@@ -1,0 +1,1 @@
+repository = https://github.com/NethermindEth/asdf-voyager-verifier.git


### PR DESCRIPTION
## Summary

Description:

- Tool repo URL: https://github.com/NethermindEth/starknet-contract-verifier
- Plugin repo URL: https://github.com/NethermindEth/asdf-voyager-verifier

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
