### PR TITLE
feat: Add tealdeer, kubebench and micro

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,6 +468,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | kube-credential-cache         | [ryodocx/kube-credential-cache](https://github.com/ryodocx/kube-credential-cache)                                 |
 | kube-linter                   | [devlincashman/asdf-kube-linter](https://github.com/devlincashman/asdf-kube-linter)                               |
 | kube-score                    | [bageljp/asdf-kube-score](https://github.com/bageljp/asdf-kube-score)                                             |
+| kubebench                     | [sarg3nt/asdf-kubebench](https://github.com/sarg3nt/asdf-kube-bench)                                              |
 | kubebuilder                   | [virtualstaticvoid/asdf-kubebuilder](https://github.com/virtualstaticvoid/asdf-kubebuilder)                       |
 | kubecm                        | [samhvw8/asdf-kubecm](https://github.com/samhvw8/asdf-kubecm)                                                     |
 | kubecolor                     | [dex4er/asdf-kubecolor](https://github.com/dex4er/asdf-kubecolor)                                                 |
@@ -535,6 +536,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | Memcached                     | [furkanural/asdf-memcached](https://github.com/furkanural/asdf-memcached)                                         |
 | Mercury                       | [susurri/asdf-mercury](https://github.com/susurri/asdf-mercury)                                                   |
 | Meson                         | [asdf-community/asdf-meson](https://github.com/asdf-community/asdf-meson)                                         |
+| Micro                         | [sarg3nt/asdf-micro](https://github.com/sarg3nt/asdf-micro)                                                       |
 | Micronaut                     | [xafarr/asdf-micronaut](https://github.com/xafarr/asdf-micronaut)                                                 |
 | Mill                          | [asdf-community/asdf-mill](https://github.com/asdf-community/asdf-mill)                                           |
 | mimirtool                     | [asdf-community/asdf-mimirtool](https://github.com/asdf-community/asdf-mimirtool)                                 |
@@ -769,6 +771,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | Tanzu CLI (tanzu)             | [vmware-tanzu/tanzu-plug-in-for-asdf](https://github.com/vmware-tanzu/tanzu-plug-in-for-asdf)                     |
 | Task                          | [particledecay/asdf-task](https://github.com/particledecay/asdf-task)                                             |
 | tctl                          | [eko/asdf-tctl](https://github.com/eko/asdf-tctl)                                                                 |
+| tealdeer                      | [sarg3/asdf-tealdeer](https://github.com/sarg3nt/asdf-tealdeer)                                                   |
 | Tekton-cli                    | [johnhamelink/asdf-tekton-cli](https://github.com/johnhamelink/asdf-tekton-cli)                                   |
 | Tekton pipeline-as-code CLI   | [ifireball/asdf-tekton-pac-cli](https://github.com/ifireball/asdf-tekton-pac-cli)                                 |
 | Teleport Enterprise           | [highb/asdf-teleport-ent](https://github.com/highb/asdf-teleport-ent)                                             |

--- a/plugins/kubebench
+++ b/plugins/kubebench
@@ -1,0 +1,1 @@
+repository = https://github.com/sarg3nt/asdf-kube-bench

--- a/plugins/micro
+++ b/plugins/micro
@@ -1,0 +1,1 @@
+repository = https://github.com/sarg3nt/asdf-micro

--- a/plugins/tealdeer
+++ b/plugins/tealdeer
@@ -1,0 +1,1 @@
+repository = https://github.com/sarg3nt/asdf-tealdeer


### PR DESCRIPTION
## Summary

Description:

**tealdeer**
- Tool repo URL: https://github.com/tealdeer-rs/tealdeer
- Plugin repo URL: https://github.com/sarg3nt/asdf-tealdeer

**kubebench**
- Tool repo URL: https://github.com/aquasecurity/kube-bench
- Plugin repo URL: https://github.com/sarg3nt/asdf-kubebench

**micro**
- Tool repo URL: https://github.com/zyedidia/micro
- Plugin repo URL: https://github.com/sarg3nt/asdf-micro

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
