### PR TITLE
feat: add asdf-gambit

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | Gauche                        | [sakuro/asdf-gauche](https://github.com/sakuro/asdf-gauche)                                                       |
 | gallery-dl                    | [iul1an/asdf-gallery-dl](https://github.com/iul1an/asdf-gallery-dl)                                               |
 | gam                           | [offbyone/asdf-gam](https://github.com/offbyone/asdf-gam)                                                         |
+| Gambit                        | [joeljuca/asdf-gambit](https://github.com/joeljuca/asdf-gambit)                                                   |
 | gator                         | [MxNxPx/asdf-gator](https://github.com/MxNxPx/asdf-gator)                                                         |
 | garden-cli                    | [rynkowsg/asdf-garden-cli](https://github.com/rynkowsg/asdf-garden-cli)                                           |
 | gcc-arm-none-eabi             | [dlech/asdf-gcc-arm-none-eabi](https://github.com/dlech/asdf-gcc-arm-none-eabi)                                   |

--- a/plugins/gambit
+++ b/plugins/gambit
@@ -1,0 +1,1 @@
+repository = https://github.com/joeljuca/asdf-gambit.git


### PR DESCRIPTION
## Summary

Description:

- Tool repo URL: https://github.com/gambit/gambit
- Plugin repo URL: https://github.com/joeljuca/asdf-gambit/

## Checklist

- [x] Format with `scripts/format.bash` (I moved this file into a `Makefile`; still it works perfectly)
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
