### PR TITLE
fix: replace qdns plugin with fixed fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -643,7 +643,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | PureScript                    | [jrrom/asdf-purescript](https://github.com/jrrom/asdf-purescript)                                                 |
 | Purty                         | [nsaunders/asdf-purty](https://github.com/nsaunders/asdf-purty)                                                   |
 | Python                        | [danhper/asdf-python](https://github.com/danhper/asdf-python)                                                     |
-| q                             | [moritz-makandra/asdf-plugin-qdns](https://github.com/moritz-makandra/asdf-plugin-qdns)                           |
+| q                             | [eheinle-mak/asdf-plugin-qdns](https://github.com/eheinle-mak/asdf-plugin-qdns)                                   |
 | qsv                           | [vjda/asdf-qsv](https://github.com/vjda/asdf-qsv)                                                                 |
 | Quarkus CLI                   | [asdf-community/asdf-quarkus](https://github.com/asdf-community/asdf-quarkus)                                     |
 | R                             | [asdf-community/asdf-r](https://github.com/asdf-community/asdf-r)                                                 |

--- a/plugins/qdns
+++ b/plugins/qdns
@@ -1,1 +1,1 @@
-repository = https://github.com/moritz-makandra/asdf-plugin-qdns.git
+repository = https://github.com/eheinle-mak/asdf-plugin-qdns.git


### PR DESCRIPTION
Enumerate available upstream versions from github releases instead of git tags. qdns upstream has issues with CI, git tags currently don't correspond to releases. Ask Github API for available versions instead.

Why the fork instead of contributing to the original plugin: My colleague no longer works with my company, they won't be able to fix the current plugin.

## Summary

Description:

- Tool repo URL: https://github.com/natesales/q
- Plugin repo URL: https://github.com/eheinle-mak/asdf-plugin-qdns.git

## Checklist

- [X] Format with `scripts/format.bash`
- [X] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [X] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
