### PR TITLE
Remove Hamler Lang plugin as it's not maintained anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,7 +363,6 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | gum                           | [lwiechec/asdf-gum](https://github.com/lwiechec/asdf-gum)                                                         |
 | gwvault                       | [GoodwayGroup/asdf-gwvault](https://github.com/GoodwayGroup/asdf-gwvault)                                         |
 | hadolint                      | [devlincashman/asdf-hadolint](https://github.com/devlincashman/asdf-hadolint)                                     |
-| Hamler                        | [scudelletti/asdf-hamler](https://github.com/scudelletti/asdf-hamler)                                             |
 | has                           | [sylvainmetayer/asdf-has](https://github.com/sylvainmetayer/asdf-has)                                             |
 | Haskell                       | [asdf-community/asdf-haskell](https://github.com/asdf-community/asdf-haskell)                                     |
 | Haskell Language Server (HLS) | [sestrella/asdf-ghcup](https://github.com/sestrella/asdf-ghcup)                                                   |

--- a/plugins/hamler
+++ b/plugins/hamler
@@ -1,1 +1,0 @@
-repository = https://github.com/scudelletti/asdf-hamler.git


### PR DESCRIPTION
Hello there.

[The Hamler Programming Language](https://github.com/hamler-lang/hamler) is not maintained anymore and therefore maintaining its plugin doesn't make much sense. Therefore I'd like to remove it.
I'll soon delete the plugin repo.

Please let me know if I need to remove any other reference to it.

Thank you for maintaining ASDF. 🙇 


EDIT: CI is red but I think that makes sense as its trying to test a plugin that's being removed