### PR TITLE
feat: add `wasp` plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -851,6 +851,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | wasm3                         | [tachyonicbytes/asdf-wasm3](https://github.com/tachyonicbytes/asdf-wasm3)                                         |
 | wasmer                        | [tachyonicbytes/asdf-wasmer](https://github.com/tachyonicbytes/asdf-wasmer)                                       |
 | wasmtime                      | [tachyonicbytes/asdf-wasmtime](https://github.com/tachyonicbytes/asdf-wasmtime)                                   |
+| wasp                          | [wasp-lang/asdf-wasp](https://github.com/wasp-lang/asdf-wasp)                                                     |
 | Waypoint                      | [asdf-community/asdf-hashicorp](https://github.com/asdf-community/asdf-hashicorp)                                 |
 | weave-gitops                  | [deas/asdf-weave-gitops](https://github.com/deas/asdf-weave-gitops)                                               |
 | Websocat                      | [bdellegrazie/asdf-websocat](https://github.com/bdellegrazie/asdf-websocat)                                       |

--- a/plugins/wasp
+++ b/plugins/wasp
@@ -1,0 +1,1 @@
+repository = https://github.com/wasp-lang/asdf-wasp.git


### PR DESCRIPTION
## Summary

Description: Adds the `wasp` plugin

- Tool repo URL: https://github.com/wasp-lang/wasp
- Plugin repo URL: https://github.com/wasp-lang/asdf-wasp

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/wasp`
- [x] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
