### PR TITLE
feat: add asdf-valkey plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -833,6 +833,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | vale                          | [pdemagny/asdf-vale](https://github.com/pdemagny/asdf-vale)                                                       |
 | vals                          | [dex4er/asdf-vals](https://github.com/dex4er/asdf-vals)                                                           |
 | Vault                         | [asdf-community/asdf-hashicorp](https://github.com/asdf-community/asdf-hashicorp)                                 |
+| Valkey                        | [chytreg/asdf-valkey](https://github.com/chytreg/asdf-valkey)                                                     |
 | Velero                        | [looztra/asdf-velero](https://github.com/looztra/asdf-velero)                                                     |
 | vendir                        | [vmware-tanzu/asdf-carvel](https://github.com/vmware-tanzu/asdf-carvel)                                           |
 | Venom                         | [aabouzaid/asdf-venom](https://github.com/aabouzaid/asdf-venom)                                                   |

--- a/plugins/valkey
+++ b/plugins/valkey
@@ -1,0 +1,1 @@
+repository = https://github.com/chytreg/asdf-valkey.git


### PR DESCRIPTION
## Summary

Description:

- Tool repo URL: https://github.com/valkey-io/valkey
- Plugin repo URL: https://github.com/chytreg/asdf-valkey

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/valkey`
- [x] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_
  - Done: https://github.com/chytreg/asdf-valkey/actions/runs/17267331589

<!-- Thank you for contributing to asdf-plugins! -->
