### PR TITLE
feat: update repository urls for eza, fzf and zoxide

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | Evans                         | [goki90210/asdf-evans](https://github.com/goki90210/asdf-evans)                                                   |
 | exa                           | [nyrst/asdf-exa](https://github.com/nyrst/asdf-exa)                                                               |
 | exercism                      | [bheesham/asdf-exercism](https://gitlab.com/bheesham/asdf-exercism)                                               |
-| eza                           | [lwiechec/asdf-eza](https://github.com/lwiechec/asdf-eza)                                                         |
+| eza                           | [pauloedurezende/asdf-eza](https://github.com/pauloedurezende/asdf-eza)                                           |
 | falco                         | [ronnnnn/asdf-falco](https://github.com/ronnnnn/asdf-falco)                                                       |
 | fastlane                      | [mollyIV/asdf-fastlane](https://github.com/mollyIV/asdf-fastlane)                                                 |
 | fd                            | [wt0f/asdf-fd](https://gitlab.com/wt0f/asdf-fd)                                                                   |
@@ -298,7 +298,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | func-e                        | [carnei-ro/asdf-func-e](https://github.com/carnei-ro/asdf-func-e)                                                 |
 | Furyctl                       | [sighupio/asdf-furyctl](https://github.com/sighupio/asdf-furyctl)                                                 |
 | fx                            | [wt0f/asdf-fx](https://gitlab.com/wt0f/asdf-fx)                                                                   |
-| fzf                           | [kompiro/asdf-fzf](https://github.com/kompiro/asdf-fzf)                                                           |
+| fzf                           | [pauloedurezende/asdf-fzf](https://github.com/pauloedurezende/asdf-fzf)                                           |
 | Gauche                        | [sakuro/asdf-gauche](https://github.com/sakuro/asdf-gauche)                                                       |
 | gallery-dl                    | [iul1an/asdf-gallery-dl](https://github.com/iul1an/asdf-gallery-dl)                                               |
 | gam                           | [offbyone/asdf-gam](https://github.com/offbyone/asdf-gam)                                                         |
@@ -885,5 +885,5 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | zigmod                        | [mise-plugins/asdf-zigmod](https://github.com/mise-plugins/asdf-zigmod)                                           |
 | zls                           | [miome/asdf-zls](https://github.com/m1ome/asdf-zls)                                                               |
 | Zola                          | [salasrod/asdf-zola](https://github.com/salasrod/asdf-zola)                                                       |
-| zoxide                        | [nyrst/asdf-zoxide](https://github.com/nyrst/asdf-zoxide)                                                         |
+| zoxide                        | [pauloedurezende/asdf-zoxide](https://github.com/pauloedurezende/asdf-zoxide)                                     |
 | zprint                        | [carlduevel/asdf-zprint](https://github.com/carlduevel/asdf-zprint)                                               |

--- a/plugins/eza
+++ b/plugins/eza
@@ -1,1 +1,1 @@
-repository = https://github.com/lwiechec/asdf-eza.git
+repository = https://github.com/pauloedurezende/asdf-eza.git

--- a/plugins/fzf
+++ b/plugins/fzf
@@ -1,1 +1,1 @@
-repository = https://github.com/kompiro/asdf-fzf.git
+repository = https://github.com/pauloedurezende/asdf-fzf.git

--- a/plugins/zoxide
+++ b/plugins/zoxide
@@ -1,1 +1,1 @@
-repository = https://github.com/nyrst/asdf-zoxide
+repository = https://github.com/pauloedurezende/asdf-zoxide.git


### PR DESCRIPTION
## Summary

### eza
A modern, maintained replacement for ls written in Rust, with better defaults and rich formatting.

-  Tool repo URL: https://github.com/eza-community/eza
-  Plugin repo URL: https://github.com/pauloedurezende/asdf-eza

### zoxide
A smarter cd command that learns your most frequently visited directories.

-  Tool repo URL: https://github.com/ajeetdsouza/zoxide
-  Plugin repo URL: https://github.com/pauloedurezende/asdf-zoxide

### fzf
A general-purpose command-line fuzzy finder.

-  Tool repo URL: https://github.com/junegunn/fzf
-  Plugin repo URL: https://github.com/pauloedurezende/asdf-fzf

## Checklist

-  [X] Format with `scripts/format.bash`
-  [X] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
-  [X] Your plugin CI tests are green

## Motivations for Changing Plugin Links

This pull request proposes updating the plugin links for `eza`, `zoxide`, and `fzf` in the `asdf-plugins` repository to ensure reliable installations and ongoing maintenance.

1. **`eza`** Plugin:
    - The previous plugin downloaded precompiled binaries via [cargo-quickinstall](https://github.com/cargo-bins/cargo-quickinstall). Those releases are no longer available, leading to download failures. The new plugin downloads the official source tarballs directly from the [upstream repository](https://github.com/eza-community/eza) and builds locally on the user’s machine. This avoids third-party outages and mitigates risks from untrusted prebuilt artifacts that could potentially compromise users’ environments.

2. **`zoxide`** Plugin:
    - The previously referenced repository is nonexistent on GitHub, preventing installation of the plugin via asdf. The new repository provides a maintained, working plugin so users can install and manage zoxide versions reliably.

3. **`fzf`** Plugin:
    - The existing repository has been unstable, intermittently allowing installation and at other times becoming unavailable. The new plugin repository offers a stable source with consistent availability, ensuring dependable installations through asdf.

These updates are intended to restore reliability, improve security, and provide a consistent installation experience for all users of `eza`, `zoxide`, and `fzf`. I appreciate your consideration and am available for any questions or adjustments.