### PR TITLE
feat: add podman plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -619,6 +619,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | Please                        | [asdf-community/asdf-please](https://github.com/asdf-community/asdf-please)                                       |
 | Pluto                         | [FairwindsOps/asdf-pluto](https://github.com/FairwindsOps/asdf-pluto)                                             |
 | pnpm                          | [jonathanmorley/asdf-pnpm](https://github.com/jonathanmorley/asdf-pnpm)                                           |
+| Podman                        | [bgaillard/asdf-podman](https://github.com/bgaillard/asdf-podman)                                       |
 | Poetry                        | [asdf-community/asdf-poetry](https://github.com/asdf-community/asdf-poetry)                                       |
 | Polaris                       | [particledecay/asdf-polaris](https://github.com/particledecay/asdf-polaris)                                       |
 | Popeye                        | [nlamirault/asdf-popeye](https://github.com/nlamirault/asdf-popeye)                                               |

--- a/plugins/podman
+++ b/plugins/podman
@@ -1,0 +1,1 @@
+repository = https://github.com/asdf-community/asdf-poetry.git

--- a/plugins/poetry
+++ b/plugins/poetry
@@ -1,1 +1,1 @@
-repository = https://github.com/asdf-community/asdf-poetry.git
+repository = https://github.com/bgaillard/asdf-podman.git


### PR DESCRIPTION
## Summary

Description:

- Tool repo URL: https://github.com/containers/podman
- Plugin repo URL: https://github.com/bgaillard/asdf-podman

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
