### PR TITLE
feat: add Github client (gh) plugin

### DIFF
--- a/plugins/gh
+++ b/plugins/gh
@@ -1,0 +1,1 @@
+repository = https://github.com/rsvalerio/asdf-gh.git


### PR DESCRIPTION
## Summary

Description:

- Tool repo URL: https://cli.github.com
- Plugin repo URL: https://github.com/asdf-vm/asdf-gh

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green
