### PR TITLE
feat: add angular-cli plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | amass                         | [dhoeric/asdf-amass](https://github.com/dhoeric/asdf-amass)                                                       |
 | Amazon ECR Credential Helper  | [dex4er/asdf-amazon-ecr-credential-helper](https://github.com/dex4er/asdf-amazon-ecr-credential-helper)           |
 | Ambient                       | [jtakakura/asdf-ambient](https://github.com/jtakakura/asdf-ambient)                                               |
+| angular-cli                   | [dainer88/asdf-angular-cli](https://github.com/dainer88/asdf-angular-cli)                                         |
 | Ansible (ansible-base)        | [amrox/asdf-pyapp](https://github.com/amrox/asdf-pyapp)                                                           |
 | ant                           | [jackboespflug/asdf-ant](https://github.com/jackboespflug/asdf-ant)                                               |
 | Apache Jmeter                 | [comdotlinux/asdf-jmeter](https://github.com/comdotlinux/asdf-jmeter)                                             |

--- a/plugins/angular-cli
+++ b/plugins/angular-cli
@@ -1,0 +1,1 @@
+repository = https://github.com/dainer88/asdf-angular-cli.git


### PR DESCRIPTION
## Summary

Description: 

- Tool repo URL: https://angular.dev/tools/cli
- Plugin repo URL: https://github.com/dainer88/asdf-angular-cli

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
