### PR TITLE
feat: add virtctl plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -843,6 +843,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | vhs                           | [chessmango/asdf-vhs](https://github.com/chessmango/asdf-vhs)                                                     |
 | Viddy                         | [ryodocx/asdf-viddy](https://github.com/ryodocx/asdf-viddy)                                                       |
 | Vim                           | [tsuyoshicho/asdf-vim](https://github.com/tsuyoshicho/asdf-vim)                                                   |
+| virtctl                       | [balanza/asdf-virtctl](https://github.com/balanza/asdf-virtctl)                                                   |
 | vlt                           | [asdf-community/asdf-hashicorp](https://github.com/asdf-community/asdf-hashicorp)                                 |
 | vultr-cli                     | [ikuradon/asdf-vultr-cli](https://github.com/ikuradon/asdf-vultr-cli)                                             |
 | watchexec                     | [nyrst/asdf-watchexec](https://github.com/nyrst/asdf-watchexec)                                                   |

--- a/plugins/virtctl
+++ b/plugins/virtctl
@@ -1,0 +1,1 @@
+repository = https://github.com/balanza/asdf-virtctl.git


### PR DESCRIPTION
## Summary

Description:

- Tool repo URL: https://github.com/kubevirt/kubevirt
- Plugin repo URL: https://github.com/balanza/asdf-virtctl

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
