### PR TITLE
feat: add tfsort IAC tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -796,6 +796,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | tfmigrate                     | [dex4er/asdf-tfmigrate](https://github.com/dex4er/asdf-tfmigrate)                                                 |
 | tfnotify                      | [jnavarrof/asdf-tfnotify](https://github.com/jnavarrof/asdf-tfnotify)                                             |
 | TFSec                         | [woneill/asdf-tfsec](https://github.com/woneill/asdf-tfsec)                                                       |
+| tfsort                        | [davidjeddy/asdf-tfsort](https://github.com/davidjeddy/asdf-tfsort)                                               |
 | tfstate-lookup                | [carnei-ro/asdf-tfstate-lookup](https://github.com/carnei-ro/asdf-tfstate-lookup)                                 |
 | tfswitch                      | [iul1an/asdf-tfswitch](https://github.com/iul1an/asdf-tfswitch)                                                   |
 | tfupdate                      | [yuokada/asdf-tfupdate](https://github.com/yuokada/asdf-tfupdate)                                                 |

--- a/plugins/tfsort
+++ b/plugins/tfsort
@@ -1,0 +1,1 @@
+repository = https://github.com/davidjeddy/asdf-tfsort.git


### PR DESCRIPTION
## Summary

Description:

- Tool repo URL: https://github.com/AlexNabokikh/tfsort
- Plugin repo URL: https://github.com/davidjeddy/asdf-tfsort

## Checklist

- [X] Format with `scripts/format.bash`
- [X] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [X] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
