### PR TITLE
chore: update Terramate plugin to use the official repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -785,7 +785,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | Terraform-validator           | [looztra/asdf-terraform-validator](https://github.com/looztra/asdf-terraform-validator)                           |
 | Terraformer                   | [gr1m0h/asdf-terraformer](https://github.com/gr1m0h/asdf-terraformer)                                             |
 | Terragrunt                    | [gruntwork-io/asdf-terragrunt](https://github.com/gruntwork-io/asdf-terragrunt)                                   |
-| Terramate                     | [martinlindner/asdf-terramate](https://github.com/martinlindner/asdf-terramate)                                   |
+| Terramate                     | [terramate-io/asdf-terramate-ce](https://github.com/terramate-io/asdf-terramate-ce)                               |
 | Terrascan                     | [hpdobrica/asdf-terrascan](https://github.com/hpdobrica/asdf-terrascan)                                           |
 | tf (hashi terraform wrapper)  | [dex4er/asdf-tf](https://github.com/dex4er/asdf-tf)                                                               |
 | tfcmt                         | [nasa9084/asdf-tfcmt](https://github.com/nasa9084/asdf-tfcmt)                                                     |

--- a/plugins/terramate
+++ b/plugins/terramate
@@ -1,1 +1,1 @@
-repository = https://github.com/martinlindner/asdf-terramate.git
+repository = https://github.com/terramate-io/asdf-terramate-ce.git


### PR DESCRIPTION
## Summary

Description:

This pull request updates the existing Terramate plugin to use the new official plugin repo instead of the unmaintained 3rd party repo that is currently being used.

The [currently used repository](https://github.com/martinlindner/asdf-terramate) has been unmaintained for 3 years despite a few attempts to update it by our organization.
See PRs:
https://github.com/martinlindner/asdf-terramate/pull/3
https://github.com/martinlindner/asdf-terramate/pull/4

I am submitting this PR on behalf of Terramate following the creation of a [new plugin repo](https://github.com/terramate-io/asdf-terramate-ce) in our official GitHub organization that will be maintained and updated by Terramate.

- Tool repo URL: https://github.com/terramate-io/terramate
- Plugin repo URL: https://github.com/terramate-io/asdf-terramate-ce

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
