### PR TITLE
feat: add Terramate Catalyst plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -786,6 +786,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | Terraformer                   | [gr1m0h/asdf-terraformer](https://github.com/gr1m0h/asdf-terraformer)                                             |
 | Terragrunt                    | [gruntwork-io/asdf-terragrunt](https://github.com/gruntwork-io/asdf-terragrunt)                                   |
 | Terramate                     | [martinlindner/asdf-terramate](https://github.com/martinlindner/asdf-terramate)                                   |
+| Terramate Catalyst            | [terramate-io/asdf-terramate-catalyst](https://github.com/terramate-io/asdf-terramate-catalyst)                   |
 | Terrascan                     | [hpdobrica/asdf-terrascan](https://github.com/hpdobrica/asdf-terrascan)                                           |
 | tf (hashi terraform wrapper)  | [dex4er/asdf-tf](https://github.com/dex4er/asdf-tf)                                                               |
 | tfcmt                         | [nasa9084/asdf-tfcmt](https://github.com/nasa9084/asdf-tfcmt)                                                     |

--- a/plugins/terramate-catalyst
+++ b/plugins/terramate-catalyst
@@ -1,0 +1,1 @@
+repository = https://github.com/terramate-io/asdf-terramate-catalyst.git


### PR DESCRIPTION
## Summary

Description:
We recently released [Terramate Catalyst](https://github.com/terramate-io/terramate-catalyst) and we would like to add it to `asdf-plugins` alongside [Terramate](https://github.com/terramate-io/terramate) (CE).

- Tool repo URL: https://github.com/terramate-io/terramate-catalyst
- Plugin repo URL: https://github.com/terramate-io/asdf-terramate-catalyst

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
