### PR TITLE
feat: add codex plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | CocoaPods                     | [ronnnnn/asdf-cocoapods](https://github.com/ronnnnn/asdf-cocoapods)                                               |
 | Codefresh                     | [gurukulkarni/asdf-codefresh](https://github.com/gurukulkarni/asdf-codefresh)                                     |
 | CodeQL                        | [bored-engineer/asdf-codeql](https://github.com/bored-engineer/asdf-codeql)                                       |
+| codex                         | [TimothyMerlin/asdf-codex](https://github.com/TimothyMerlin/asdf-codex)                                           |
 | Colima                        | [CrouchingMuppet/asdf-colima](https://github.com/CrouchingMuppet/asdf-colima)                                     |
 | coredns                       | [s3than/asdf-coredns](https://github.com/s3than/asdf-coredns)                                                     |
 | Conan                         | [amrox/asdf-pyapp](https://github.com/amrox/asdf-pyapp)                                                           |

--- a/plugins/codex
+++ b/plugins/codex
@@ -1,0 +1,1 @@
+repository = https://github.com/TimothyMerlin/asdf-codex.git


### PR DESCRIPTION
## Summary

Description:

- Tool repo URL: https://github.com/openai/codex
- Plugin repo URL: https://github.com/TimothyMerlin/asdf-codex

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
