### PR TITLE
feat: add Homebrew-PHP plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | hishtory                      | [asdf-community/asdf-hishtory](https://github.com/asdf-community/asdf-hishtory)                                   |
 | hledger                       | [airtonix/hledger](https://github.com/airtonix/asdf-hledger)                                                      |
 | hledger-flow                  | [airtonix/hledger-flow](https://github.com/airtonix/asdf-hledger-flow)                                            |
+| Homebrew-PHP                  | [naviapps/asdf-homebrew-php](https://github.com/naviapps/asdf-homebrew-php)                                       |
 | hostctl                       | [svenluijten/asdf-hostctl](https://github.com/svenluijten/asdf-hostctl)                                           |
 | httpie-go                     | [abatilo/asdf-httpie-go](https://github.com/abatilo/asdf-httpie-go)                                               |
 | Hub                           | [claygorman/asdf-hub](https://github.com/claygorman/asdf-hub)                                                     |

--- a/plugins/homebrew-php
+++ b/plugins/homebrew-php
@@ -1,0 +1,1 @@
+repository = https://github.com/naviapps/asdf-homebrew-php.git


### PR DESCRIPTION
## Summary

Description:

- Homebrew-based PHP plugin for asdf and mise.  
  Installs PHP via the `shivammathur/homebrew-php` tap on macOS.

- Tool repo URL: https://github.com/naviapps/asdf-homebrew-php
- Plugin repo URL: https://github.com/naviapps/asdf-homebrew-php

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/homebrew-php`
- [x] Your plugin CI tests are green
  - _Tip: using the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in plugin CI_