### PR TITLE
feat: add homebrew-php plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | hishtory                      | [asdf-community/asdf-hishtory](https://github.com/asdf-community/asdf-hishtory)                                   |
 | hledger                       | [airtonix/hledger](https://github.com/airtonix/asdf-hledger)                                                      |
 | hledger-flow                  | [airtonix/hledger-flow](https://github.com/airtonix/asdf-hledger-flow)                                            |
+| Homebrew-PHP                  | [naviapps/asdf-homebrew-php](https://github.com/naviapps/asdf-homebrew-php)                                       |
 | hostctl                       | [svenluijten/asdf-hostctl](https://github.com/svenluijten/asdf-hostctl)                                           |
 | httpie-go                     | [abatilo/asdf-httpie-go](https://github.com/abatilo/asdf-httpie-go)                                               |
 | Hub                           | [claygorman/asdf-hub](https://github.com/claygorman/asdf-hub)                                                     |

--- a/plugins/homebrew-php
+++ b/plugins/homebrew-php
@@ -1,0 +1,1 @@
+repository = https://github.com/naviapps/asdf-homebrew-php.git


### PR DESCRIPTION
## Summary

Description:

Re-submission of the plugin entry proposed in #1129.  
The original PR was automatically closed when my fork was deleted.

This plugin provides Homebrew-based PHP version switching for asdf and mise on macOS.  
It is intended for environments where Homebrew PHP is already standard, offering a simple alternative to source-build PHP plugins, which can behave less predictably on macOS due to frequent Homebrew dependency changes.

- Tool repo URL: https://github.com/naviapps/asdf-homebrew-php
- Plugin repo URL: https://github.com/naviapps/asdf-homebrew-php

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_