### PR TITLE
feat: add pdktk support

### DIFF
--- a/README.md
+++ b/README.md
@@ -604,6 +604,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | pandoc-crossref               | [sys9kdr/asdf-pandoc-crossref](https://github.com/sys9kdr/asdf-pandoc-crossref)                                   |
 | patat                         | [airtonix/asdf-patat](https://github.com/airtonix/asdf-patat)                                                     |
 | peco                          | [asdf-community/asdf-peco](https://github.com/asdf-community/asdf-peco)                                           |
+| pdftk                         | [lakshanwd/asdf-pdftk](https://github.com/lakshanwd/asdf-pdftk)                                                   |
 | pdm                           | [1oglop1/asdf-pdm](https://github.com/1oglop1/asdf-pdm)                                                           |
 | Perl                          | [ouest/asdf-perl](https://github.com/ouest/asdf-perl)                                                             |
 | PHP                           | [asdf-community/asdf-php](https://github.com/asdf-community/asdf-php)                                             |

--- a/plugins/pdftk
+++ b/plugins/pdftk
@@ -1,0 +1,1 @@
+repository = https://github.com/lakshanwd/asdf-pdftk.git


### PR DESCRIPTION
## Summary

Description:

- Tool repo URL: https://gitlab.com/pdftk-java
- Plugin repo URL: https://github.com/lakshanwd/asdf-pdftk

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
