### PR TITLE
feat: add wtp plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -858,6 +858,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | Wren CLI                      | [jtakakura/asdf-wren-cli](https://github.com/jtakakura/asdf-wren-cli)                                             |
 | wrk                           | [ivanvc/asdf-wrk](https://github.com/ivanvc/asdf-wrk)                                                             |
 | Wtfutil                       | [NeoHsu/asdf-wtfutil](https://github.com/NeoHsu/asdf-wtfutil)                                                     |
+| wtp                           | [ouest/asdf-wtp](https://github.com/ouest/asdf-wtp)                                                               |
 | XCTestHTMLReport              | [younke/asdf-xchtmlreport](https://github.com/younke/asdf-xchtmlreport)                                           |
 | XcodeGen                      | [younke/asdf-xcodegen](https://github.com/younke/asdf-xcodegen)                                                   |
 | xc                            | [airtonix/asdf-xc](https://github.com/airtonix/asdf-xc)                                                           |

--- a/plugins/wtp
+++ b/plugins/wtp
@@ -1,0 +1,1 @@
+repository = https://github.com/ouest/asdf-wtp.git


### PR DESCRIPTION
## Summary

Description:

- Tool repo URL: https://github.com/satococoa/wtp
- Plugin repo URL: https://github.com/ouest/asdf-wtp

## Checklist

- [X] Format with `scripts/format.bash`
- [X] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [X] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
