### PR TITLE
feat: update aws-vault repository to asdf-community maintenance fork

### DIFF
--- a/plugins/aws-vault
+++ b/plugins/aws-vault
@@ -1,1 +1,1 @@
-repository = https://github.com/karancode/asdf-aws-vault.git
+repository = https://github.com/asdf-community/asdf-aws-vault.git


### PR DESCRIPTION
## Summary

Original plugin points to a deprecated aws-vault repo, update it to asdf-community maintenance fork so it will points to the new tool repo.

Description:

- Tool repo URL: https://github.com/ByteNess/aws-vault
- Plugin repo URL: https://github.com/asdf-community/asdf-aws-vault

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
