### PR TITLE
Add hx plugin

### DIFF
--- a/plugins/hx
+++ b/plugins/hx
@@ -1,0 +1,1 @@
+repository = https://github.com/raskell-io/asdf-hx.git


### PR DESCRIPTION
Adds hx - a Haskell toolchain CLI.

https://github.com/raskell-io/hx