### PR TITLE
fix: Change plugin link to an updated project

### DIFF
--- a/README.md
+++ b/README.md
@@ -724,7 +724,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | spacectl                      | [bodgit/asdf-spacectl](https://github.com/bodgit/asdf-spacectl)                                                   |
 | Spago                         | [jrrom/asdf-spago](https://github.com/jrrom/asdf-spago)                                                           |
 | Spark                         | [jeffryang24/asdf-spark](https://github.com/jeffryang24/asdf-spark)                                               |
-| Spectral                      | [vbyrd/asdf-spectral](https://github.com/vbyrd/asdf-spectral)                                                     |
+| Spectral                      | [jesmarla/asdf-spectral](https://github.com/jesmarla/asdf-spectral)                                                     |
 | Spin                          | [pavloos/asdf-spin](https://github.com/pavloos/asdf-spin)                                                         |
 | spotbugs                      | [jiahuili430/asdf-spotbugs](https://github.com/jiahuili430/asdf-spotbugs)                                         |
 | Spring Boot CLI               | [joschi/asdf-spring-boot](https://github.com/joschi/asdf-spring-boot)                                             |

--- a/plugins/spectral
+++ b/plugins/spectral
@@ -1,1 +1,1 @@
-repository = https://github.com/vbyrd/asdf-spectral.git
+repository = https://github.com/jesmarla/asdf-spectral.git


### PR DESCRIPTION
## Summary

Description:
This plugin contains bugs that prevent the installation of packages newer than a very old, specific version.

After attempting to contact the repository owner and submit a pull request in their project, and after receiving no response, I request a change to point the repository link to my project.

Here you can see my attempt to solve the issues on the current project a year and a half ago:
https://github.com/vbyrd/asdf-spectral/pull/8
