### PR TITLE
fix: drop watchexec

### DIFF
--- a/README.md
+++ b/README.md
@@ -845,7 +845,6 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | Vim                           | [tsuyoshicho/asdf-vim](https://github.com/tsuyoshicho/asdf-vim)                                                   |
 | vlt                           | [asdf-community/asdf-hashicorp](https://github.com/asdf-community/asdf-hashicorp)                                 |
 | vultr-cli                     | [ikuradon/asdf-vultr-cli](https://github.com/ikuradon/asdf-vultr-cli)                                             |
-| watchexec                     | [nyrst/asdf-watchexec](https://github.com/nyrst/asdf-watchexec)                                                   |
 | WASI SDK                      | [coolreader18/asdf-wasi-sdk](https://github.com/coolreader18/asdf-wasi-sdk)                                       |
 | WASM-4                        | [jtakakura/asdf-wasm4](https://github.com/jtakakura/asdf-wasm4)                                                   |
 | wasm3                         | [tachyonicbytes/asdf-wasm3](https://github.com/tachyonicbytes/asdf-wasm3)                                         |

--- a/plugins/watchexec
+++ b/plugins/watchexec
@@ -1,1 +1,0 @@
-repository = https://github.com/nyrst/asdf-watchexec.git


### PR DESCRIPTION
## Summary

Description:

Remove `watchexec`, since the source is gone, along with its user. And a quick search didn't show any forks to replace.

- Tool repo URL: https://github.com/watchexec/watchexec
- Plugin repo URL: https://github.com/nyrst/asdf-watchexec

## Checklist

- [X] Format with `scripts/format.bash`
- [ ] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [ ] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
