### PR TITLE
feat: add oxlint plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -595,6 +595,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | opentofu                      | [virtualroot/asdf-opentofu](https://github.com/virtualroot/asdf-opentofu)                                         |
 | Operator SDK                  | [Medium/asdf-operator-sdk](https://github.com/Medium/asdf-operator-sdk)                                           |
 | Opsgenie-lamp                 | [ORCID/asdf-opsgenie-lamp](https://github.com/ORCID/asdf-opsgenie-lamp)                                           |
+| oxlint                        | [daikieng/asdf-oxlint](https://github.com/daikieng/asdf-oxlint)                                                   |
 | oras                          | [bodgit/asdf-oras](https://github.com/bodgit/asdf-oras)                                                           |
 | Osm                           | [nlamirault/asdf-osm](https://github.com/nlamirault/asdf-osm)                                                     |
 | osqueryi                      | [davidecavestro/asdf-osqueryi](https://github.com/davidecavestro/asdf-osqueryi)                                   |

--- a/plugins/oxlint
+++ b/plugins/oxlint
@@ -1,0 +1,1 @@
+repository = https://github.com/daikieng/asdf-oxlint.git


### PR DESCRIPTION
## Summary

Description: Add oxlint plugin - A fast JavaScript/TypeScript linter written in Rust

- Tool repo URL: https://github.com/oxc-project/oxc
- Plugin repo URL: https://github.com/daikieng/asdf-oxlint

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->