### PR TITLE
feat: add lazydocker plugin (#1088)

### DIFF
--- a/README.md
+++ b/README.md
@@ -499,6 +499,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | lane                          | [CodeReaper/asdf-lane](https://github.com/CodeReaper/asdf-lane)                                                   |
 | launchpad                     | [surskitt/asdf-launchpad](https://github.com/surskitt/asdf-launchpad)                                             |
 | lazygit                       | [nklmilojevic/asdf-lazygit](https://github.com/nklmilojevic/asdf-lazygit)                                         |
+| lazydocker                    | [mfandrade/asdf-lazydocker](https://github.com/mfandrade/asdf-lazydocker)                                         |
 | Lean                          | [asdf-community/asdf-lean](https://github.com/asdf-community/asdf-lean)                                           |
 | Leiningen                     | [miorimmax/asdf-lein](https://github.com/miorimmax/asdf-lein)                                                     |
 | Lefthook                      | [jtzero/asdf-lefthook](https://github.com/jtzero/asdf-lefthook)                                                   |

--- a/plugins/lazydocker
+++ b/plugins/lazydocker
@@ -1,0 +1,1 @@
+repository = https://github.com/mfandrade/asdf-lazydocker.git


### PR DESCRIPTION
## Summary

Description: Add lazydocker plugin - The lazier way to manage everything docker

- Tool repo URL: https://github.com/jesseduffield/lazydocker
- Plugin repo URL: https://github.com/mfandrade/asdf-lazydocker

## Checklist

- [X] Format with `scripts/format.bash`
- [X] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [X] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
