### PR TITLE
feat: adding workmux plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -855,6 +855,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | weave-gitops                  | [deas/asdf-weave-gitops](https://github.com/deas/asdf-weave-gitops)                                               |
 | Websocat                      | [bdellegrazie/asdf-websocat](https://github.com/bdellegrazie/asdf-websocat)                                       |
 | woodpecker-cli                | [ivanvc/asdf-woodpecker](https://github.com/ivanvc/asdf-woodpecker)                                               |
+| workmux                       | [CoolCold/asdf-workmux](https://github.com/CoolCold/asdf-workmux)                                               |
 | Wren CLI                      | [jtakakura/asdf-wren-cli](https://github.com/jtakakura/asdf-wren-cli)                                             |
 | wrk                           | [ivanvc/asdf-wrk](https://github.com/ivanvc/asdf-wrk)                                                             |
 | Wtfutil                       | [NeoHsu/asdf-wtfutil](https://github.com/NeoHsu/asdf-wtfutil)                                                     |

--- a/plugins/workmux
+++ b/plugins/workmux
@@ -1,0 +1,1 @@
+repository = https://github.com/CoolCold/asdf-workmux.git


### PR DESCRIPTION
## Summary

Add workmux to the asdf plugin index.

Description:

- Tool repo URL: https://github.com/raine/workmux
- Plugin repo URL: https://github.com/CoolCold/asdf-workmux.git

## Checklist

- [x] Format with `scripts/format.bash`
- [ ] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [ ] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
