### PR TITLE
feat: Add git-native-issue plugin

### DIFF
--- a/plugins/git-native-issue
+++ b/plugins/git-native-issue
@@ -1,0 +1,1 @@
+repository = https://github.com/remenoscodes/git-native-issue-asdf.git


### PR DESCRIPTION
## Plugin: git-native-issue

**Repository**: https://github.com/remenoscodes/git-native-issue-asdf
**Tool**: [git-native-issue](https://github.com/remenoscodes/git-native-issue) — Distributed issue tracking using Git's native data model

The plugin has:
- `bin/list-all`, `bin/download`, `bin/install` (standard structure)
- CI testing on ubuntu-latest and macos-latest
- README with usage instructions

This allows users to install via: `asdf plugin add git-native-issue && asdf install git-native-issue latest`