### PR TITLE
feat: add xnc plugin

### DIFF
--- a/plugins/xnc
+++ b/plugins/xnc
@@ -1,0 +1,1 @@
+repository = https://github.com/huru-io/asdf-xnc.git


### PR DESCRIPTION
## Summary

Add [xnc](https://github.com/huru-io/xnullclaw) — AI agent orchestration CLI that manages nullclaw agents in hardened Docker containers.

- Tool repo: https://github.com/huru-io/xnullclaw
- Plugin repo: https://github.com/huru-io/asdf-xnc

## Checklist

- [x] Plugin CI tests pass on ubuntu and macOS
- [x] ShellCheck lint passes
- [x] Plugin follows asdf plugin conventions (bin/list-all, bin/download, bin/install, bin/latest-stable)