### PR TITLE
feat: add bitwarden-desktop plugin registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | bingo                         | [isindir/asdf-bingo](https://github.com/isindir/asdf-bingo)                                                       |
 | binnacle                      | [Traackr/asdf-binnacle](https://github.com/Traackr/asdf-binnacle)                                                 |
 | Bitwarden                     | [vixus0/asdf-bitwarden](https://github.com/vixus0/asdf-bitwarden)                                                 |
+| bitwarden-desktop             | [HolyBitsLLC/asdf-bitwarden-desktop](https://github.com/HolyBitsLLC/asdf-bitwarden-desktop)                       |
 | bitwarden-secrets-manager     | [asdf-community/asdf-bitwarden-secrets-manager](https://github.com/asdf-community/asdf-bitwarden-secrets-manager) |
 | boilerplate                   | [gruntwork-io/asdf-boilerplate](https://github.com/gruntwork-io/asdf-boilerplate)                                 |
 | Bombardier                    | [NeoHsu/asdf-bombardier](https://github.com/NeoHsu/asdf-bombardier)                                               |

--- a/plugins/bitwarden-desktop
+++ b/plugins/bitwarden-desktop
@@ -1,0 +1,1 @@
+repository = https://github.com/HolyBitsLLC/asdf-bitwarden-desktop


### PR DESCRIPTION
## Summary
Tool repo URL: https://github.com/bitwarden/clients
Plugin repo URL: https://github.com/HolyBitsLLC/asdf-bitwarden-desktop

## Checklist
- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/bitwarden-desktop`
- [x] Your plugin CI tests are green: https://github.com/HolyBitsLLC/asdf-bitwarden-desktop/actions\?query\=branch%3Amain

> Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI