### PR TITLE
Remove kubefirst plugin registration

### DIFF
--- a/plugins/kubefirst
+++ b/plugins/kubefirst
@@ -1,1 +1,0 @@
-repository = https://github.com/Claywd/asdf-kubefirst


### PR DESCRIPTION
This PR removes the `kubefirst` plugin entry from the asdf plugin registry at the plugin author’s request.