### PR TITLE
feat: add sky

### DIFF
--- a/plugins/sky
+++ b/plugins/sky
@@ -1,0 +1,1 @@
+repository = https://github.com/eratio08/asdf-sky.git


### PR DESCRIPTION
## Summary

Description: Add support for the sky language cli

- Tool repo URL: https://github.com/anzellai/sky
- Plugin repo URL: https://github.com/eratio08/asdf-sky

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
