### PR TITLE
feat(plugins): add skill-audit-mcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -710,6 +710,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | Sinker                        | [elementalvoid/asdf-sinker](https://github.com/elementalvoid/asdf-sinker)                                         |
 | Skaffold                      | [nklmilojevic/asdf-skaffold](https://github.com/nklmilojevic/asdf-skaffold)                                       |
 | skate                         | [chessmango/asdf-skate](https://github.com/chessmango/asdf-skate)                                                 |
+| skill-audit-mcp               | [eltociear/asdf-skill-audit-mcp](https://github.com/eltociear/asdf-skill-audit-mcp)                               |
 | Sloth                         | [slok/asdf-sloth](https://github.com/slok/asdf-sloth)                                                             |
 | smithy                        | [aws/asdf-smithy](https://github.com/aws/asdf-smithy)                                                             |
 | SML/NJ                        | [samontea/asdf-smlnj](https://github.com/samontea/asdf-smlnj)                                                     |

--- a/plugins/skill-audit-mcp
+++ b/plugins/skill-audit-mcp
@@ -1,0 +1,1 @@
+repository = https://github.com/eltociear/asdf-skill-audit-mcp.git


### PR DESCRIPTION
## What

Adds a shortname for [`skill-audit-mcp`](https://github.com/eltociear/skill-audit-mcp).

`skill-audit-mcp` is an MCP server (and CLI) that audits MCP servers for
supply-chain attacks: credential exfiltration, prompt injection, command
injection, hidden tool poisoning. 17 rule groups / 61 regexes,
MIT-licensed, already shipped as a GitHub Action
([\`uses: eltociear/skill-audit-mcp@v1\`](https://github.com/marketplace/actions/mcp-security-audit)),
Docker image (\`ghcr.io/eltociear/skill-audit-mcp:v1\`, multi-arch),
and a hosted x402 pay-per-use endpoint.

Plugin repo: <https://github.com/eltociear/asdf-skill-audit-mcp>

## Tested locally

```
$ ./scripts/test_plugin.bash --file plugins/skill-audit-mcp
OK plugins/skill-audit-mcp
```

`bin/list-all` returns semver tags via \`git ls-remote\`; \`bin/install\`
downloads the tagged release tarball and drops a shell wrapper that
execs \`python3 server.py\`. Dependencies: bash, curl, tar, git, python3.

## Checklist

- [x] file at `plugins/skill-audit-mcp` ending with newline
- [x] `repository = ...` line pointing to a reachable git repo
- [x] README.md alphabetical entry added
- [x] `scripts/test_plugin.bash --file plugins/skill-audit-mcp` passes