### PR TITLE
feat: Add ticgit

### DIFF
--- a/README.md
+++ b/README.md
@@ -800,6 +800,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | tfswitch                      | [iul1an/asdf-tfswitch](https://github.com/iul1an/asdf-tfswitch)                                                   |
 | tfupdate                      | [yuokada/asdf-tfupdate](https://github.com/yuokada/asdf-tfupdate)                                                 |
 | tf-summarize                  | [adamcrews/asdf-tf-summarize](https://github.com/adamcrews/asdf-tf-summarize)                                     |
+| Ticgit                        | [bosmak/asdf-ticgit](https://github.com/bosmak/asdf-ticgit)                                                       |
 | Thrift                        | [alisaifee/asdf-thrift](https://github.com/alisaifee/asdf-thrift)                                                 |
 | Tilt                          | [eaceaser/asdf-tilt](https://github.com/eaceaser/asdf-tilt)                                                       |
 | Timoni                        | [Smana/asdf-timoni](https://github.com/Smana/asdf-timoni)                                                         |

--- a/plugins/ticgit
+++ b/plugins/ticgit
@@ -1,0 +1,1 @@
+repository = https://github.com/bosmak/asdf-ticgit.git


### PR DESCRIPTION
## Summary

Adds `ticgit` plugin

Description:

- Tool repo URL: https://github.com/schacon/ticgit
- Plugin repo URL: https://github.com/bosmak/asdf-ticgit

## Checklist

- [X] Format with `scripts/format.bash`
- [X] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [X] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
