### PR TITLE
feat: add varlock plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -832,6 +832,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | V                             | [jthegedus/asdf-v](https://github.com/jthegedus/asdf-v)                                                           |
 | vale                          | [pdemagny/asdf-vale](https://github.com/pdemagny/asdf-vale)                                                       |
 | vals                          | [dex4er/asdf-vals](https://github.com/dex4er/asdf-vals)                                                           |
+| varlock                       | [Langleu/asdf-varlock](https://github.com/Langleu/asdf-varlock)                                                   |
 | Vault                         | [asdf-community/asdf-hashicorp](https://github.com/asdf-community/asdf-hashicorp)                                 |
 | Velero                        | [looztra/asdf-velero](https://github.com/looztra/asdf-velero)                                                     |
 | vendir                        | [vmware-tanzu/asdf-carvel](https://github.com/vmware-tanzu/asdf-carvel)                                           |

--- a/plugins/varlock
+++ b/plugins/varlock
@@ -1,0 +1,1 @@
+repository = https://github.com/Langleu/asdf-varlock.git


### PR DESCRIPTION
## Summary

Description:

- Tool repo URL: https://github.com/dmno-dev/varlock
- Plugin repo URL: https://github.com/Langleu/asdf-varlock

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
