### PR TITLE
feat: add prek plugin

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install asdf dependencies
-        uses: asdf-vm/actions/install@v3
+        uses: asdf-vm/actions/install@v4
 
       - name: lint
         run: scripts/lint.bash

--- a/README.md
+++ b/README.md
@@ -627,6 +627,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | powerline-go                  | [dex4er/asdf-powerline-go](https://github.com/dex4er/asdf-powerline-go)                                           |
 | PowerShell                    | [daveneeley/asdf-powershell-core](https://github.com/daveneeley/asdf-powershell-core)                             |
 | pre-commit                    | [jonathanmorley/asdf-pre-commit](https://github.com/jonathanmorley/asdf-pre-commit)                               |
+| prek                          | [a4z/asdf-prek](https://github.com/a4z/asdf-prek)                                                                 |
 | process-compose               | [martino/asdf-process-compose](https://github.com/martino/asdf-process-compose)                                   |
 | promtool                      | [asdf-community/asdf-promtool](https://github.com/asdf-community/asdf-promtool)                                   |
 | protoc                        | [paxosglobal/asdf-protoc](https://github.com/paxosglobal/asdf-protoc)                                             |

--- a/plugins/prek
+++ b/plugins/prek
@@ -1,0 +1,1 @@
+repository = https://github.com/a4z/asdf-prek


### PR DESCRIPTION
## Summary

Description: Add prek, a reimagined version of pre-commit, built in Rust

- Tool repo URL:  https://github.com/j178/prek
- Plugin repo URL: https://github.com/a4z/asdf-prek

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
