### PR TITLE
feat: add openscad plugin

### DIFF
--- a/plugins/openscad
+++ b/plugins/openscad
@@ -1,0 +1,1 @@
+repository = https://github.com/wguilherme/asdf-openscad.git


### PR DESCRIPTION
## Description

Adds plugin for [OpenSCAD](https://openscad.org/), a script-based parametric 3D CAD modeler.

## Plugin

- Repository: https://github.com/wguilherme/asdf-openscad
- Supports: macOS (DMG), Linux x86_64 (AppImage)
- Tested with: `2021.01`

## Checklist

- [x] Plugin repository is public
- [x] Plugin has a README
- [x] `bin/list-all`, `bin/install`, `bin/latest-stable` implemented
- [x] Plugin name matches the tool name (`openscad`)