### PR TITLE
feat: added octl plugin (Outscale CLI)

### DIFF
--- a/plugins/octl
+++ b/plugins/octl
@@ -1,0 +1,1 @@
+repository = https://github.com/mgrechukh/asdf-octl.git


### PR DESCRIPTION
## Summary

Description:

- Tool repo URL: https://github.com/outscale/octl

- Plugin repo URL: https://github.com/mgrechukh/asdf-octl

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green

NB: CI updated and runs green