### PR TITLE
feat: add s5cmd plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -681,6 +681,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | rust-analyzer                 | [Xyven1/asdf-rust-analyzer](https://github.com/Xyven1/asdf-rust-analyzer)                                         |
 | rustic                        | [jahands/asdf-rustic](https://github.com/jahands/asdf-rustic)                                                     |
 | rye                           | [Azuki-bar/asdf-rye](https://github.com/Azuki-bar/asdf-rye)                                                       |
+| s5cmd                         | [olofvndrhr/asdf-s5cmd](https://github.com/olofvndrhr/asdf-s5cmd)                                                 |
 | saml2aws                      | [elementalvoid/asdf-saml2aws](https://github.com/elementalvoid/asdf-saml2aws)                                     |
 | SBT                           | [bram2000/asdf-sbt](https://github.com/bram2000/asdf-sbt)                                                         |
 | scaffold                      | [particledecay/asdf-scaffold](https://github.com/particledecay/asdf-scaffold)                                     |

--- a/plugins/s5cmd
+++ b/plugins/s5cmd
@@ -1,0 +1,1 @@
+repository = https://github.com/olofvndrhr/asdf-s5cmd.git


### PR DESCRIPTION
## Summary

Description:

- Tool repo URL: https://github.com/peak/s5cmd
- Plugin repo URL: https://github.com/olofvndrhr/asdf-s5cmd

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
