### PR TITLE
feat: add nub plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -574,6 +574,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | notation                      | [bodgit/asdf-notation](https://github.com/bodgit/asdf-notation)                                                   |
 | nova                          | [elementalvoid/asdf-nova](https://github.com/elementalvoid/asdf-nova)                                             |
 | NSC                           | [dex4er/asdf-nsc](https://github.com/dex4er/asdf-nsc)                                                             |
+| nub                           | [afonsojramos/asdf-nub](https://github.com/afonsojramos/asdf-nub)                                                 |
 | oapi-codegen                  | [dylanrayboss/asdf-oapi-codegen](https://github.com/dylanrayboss/asdf-oapi-codegen)                               |
 | oc                            | [sqtran/asdf-oc](https://github.com/sqtran/asdf-oc)                                                               |
 | oci                           | [yasn77/asdf-oci](https://github.com/yasn77/asdf-oci)                                                             |

--- a/plugins/nub
+++ b/plugins/nub
@@ -1,0 +1,1 @@
+repository = https://github.com/afonsojramos/asdf-nub.git


### PR DESCRIPTION
Adds a shortname for [nub](https://nubjs.com) ([nubjs/nub](https://github.com/nubjs/nub)) — a Node.js toolkit in a single static Rust binary (runs TS/JS directly, runs package scripts, npx replacement, installs against the project's existing lockfile).

Plugin: https://github.com/afonsojramos/asdf-nub
- Installs the official GitHub release binaries, SHA-256 verified against the published checksums
- darwin/linux × arm64/x64 (+ musl variants, auto-detected)
- Ships both `nub` and `nubx` (argv0 dispatch)
- CI: `asdf-vm/actions/plugin-test` on ubuntu + macos, shellcheck
- Verified locally via the raw asdf interface and via `mise plugin install` from the repo URL