### PR TITLE
feat: add nub plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -574,6 +574,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | notation                      | [bodgit/asdf-notation](https://github.com/bodgit/asdf-notation)                                                   |
 | nova                          | [elementalvoid/asdf-nova](https://github.com/elementalvoid/asdf-nova)                                             |
 | NSC                           | [dex4er/asdf-nsc](https://github.com/dex4er/asdf-nsc)                                                             |
+| nub                           | [nubjs/asdf-nub](https://github.com/nubjs/asdf-nub)                                                               |
 | oapi-codegen                  | [dylanrayboss/asdf-oapi-codegen](https://github.com/dylanrayboss/asdf-oapi-codegen)                               |
 | oc                            | [sqtran/asdf-oc](https://github.com/sqtran/asdf-oc)                                                               |
 | oci                           | [yasn77/asdf-oci](https://github.com/yasn77/asdf-oci)                                                             |

--- a/plugins/nub
+++ b/plugins/nub
@@ -1,0 +1,1 @@
+repository = https://github.com/nubjs/asdf-nub.git


### PR DESCRIPTION
Adds [nubjs/asdf-nub](https://github.com/nubjs/asdf-nub) under the short name `nub`.

[nub](https://github.com/nubjs/nub) is a Rust CLI that augments Node.js. The plugin installs the official release tarballs with SHA-256 verification; its own `plugin-test` CI is green on Linux and macOS.
