### PR TITLE
feat: add varlock plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -832,6 +832,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | V                             | [jthegedus/asdf-v](https://github.com/jthegedus/asdf-v)                                                           |
 | vale                          | [pdemagny/asdf-vale](https://github.com/pdemagny/asdf-vale)                                                       |
 | vals                          | [dex4er/asdf-vals](https://github.com/dex4er/asdf-vals)                                                           |
+| varlock                       | [rafaelassumpcao/asdf-varlock](https://github.com/rafaelassumpcao/asdf-varlock)                                   |
 | Vault                         | [asdf-community/asdf-hashicorp](https://github.com/asdf-community/asdf-hashicorp)                                 |
 | Velero                        | [looztra/asdf-velero](https://github.com/looztra/asdf-velero)                                                     |
 | vendir                        | [vmware-tanzu/asdf-carvel](https://github.com/vmware-tanzu/asdf-carvel)                                           |

--- a/plugins/varlock
+++ b/plugins/varlock
@@ -1,0 +1,1 @@
+repository = https://github.com/rafaelassumpcao/asdf-varlock.git


### PR DESCRIPTION
## Summary
- Adds `varlock` plugin entry, pointing to [rafaelassumpcao/asdf-varlock](https://github.com/rafaelassumpcao/asdf-varlock)
- [varlock](https://github.com/dmno-dev/varlock) is a schema-based env var / secrets manager

## Checklist
- [x] `scripts/test_plugin.bash --file plugins/varlock` passes
- [x] README.md updated with plugin entry, alphabetically ordered