### PR TITLE
feat: add OutageDeck plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -599,6 +599,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | oras                           | [bodgit/asdf-oras](https://github.com/bodgit/asdf-oras)                                                           |
 | Osm                            | [nlamirault/asdf-osm](https://github.com/nlamirault/asdf-osm)                                                     |
 | osqueryi                       | [davidecavestro/asdf-osqueryi](https://github.com/davidecavestro/asdf-osqueryi)                                   |
+| OutageDeck                     | [outagedeck/asdf-outagedeck](https://github.com/outagedeck/asdf-outagedeck)                                       |
 | pachctl                        | [abatilo/asdf-pachctl](https://github.com/abatilo/asdf-pachctl)                                                   |
 | Packer                         | [asdf-community/asdf-hashicorp](https://github.com/asdf-community/asdf-hashicorp)                                 |
 | Pandoc                         | [Fbrisset/asdf-pandoc](https://github.com/Fbrisset/asdf-pandoc)                                                   |

--- a/plugins/outagedeck
+++ b/plugins/outagedeck
@@ -1,0 +1,1 @@
+repository = https://github.com/outagedeck/asdf-outagedeck.git


### PR DESCRIPTION
## Summary

Description:

- Adds the `outagedeck` shortname for the official OutageDeck asdf plugin.
- Tool repo URL: https://github.com/outagedeck/cli
- Plugin repo URL: https://github.com/outagedeck/asdf-outagedeck

The plugin installs checksum-verified OutageDeck CLI release archives on
Linux and macOS for AMD64 and ARM64. Its GitHub Actions plugin test is green
on both Ubuntu and macOS.

## Checklist

- [x] Formatted with `scripts/format.bash`
- [x] Tested locally with `scripts/test_plugin.bash --file plugins/outagedeck`
- [x] Tested the complete diff with `scripts/test_plugin.bash --diff origin/master HEAD`
- [x] Plugin CI tests are green
