### PR TITLE
feat(plugin): add herdr

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,6 +383,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | Helmsman                       | [luisdavim/asdf-helmsman](https://github.com/luisdavim/asdf-helmsman)                                             |
 | Hermes                         | [cometkim/asdf-hermes](https://github.com/cometkim/asdf-hermes)                                                   |
 | heroku-cli                     | [treilly94/asdf-heroku-cli](https://github.com/treilly94/asdf-heroku-cli)                                         |
+| herdr                          | [chrisjohnson/asdf-herdr](https://github.com/chrisjohnson/asdf-herdr)                                                   |
 | hey                            | [raimon49/asdf-hey](https://github.com/raimon49/asdf-hey)                                                         |
 | hishtory                       | [asdf-community/asdf-hishtory](https://github.com/asdf-community/asdf-hishtory)                                   |
 | hledger                        | [airtonix/hledger](https://github.com/airtonix/asdf-hledger)                                                      |

--- a/plugins/herdr
+++ b/plugins/herdr
@@ -1,0 +1,1 @@
+repository = https://github.com/chrisjohnson/asdf-herdr.git


### PR DESCRIPTION
## Summary

Description:

herdr is a terminal-native agent multiplexer written in Rust. It gives every AI coding agent (Claude Code, Codex, Devin, etc.) its own real terminal pane, tracks their state automatically, and keeps them alive on a background server you can detach from and reattach to — even from your phone over SSH.

- Tool repo URL: https://github.com/ogulcancelik/herdr
- Plugin repo URL: https://github.com/chrisjohnson/asdf-herdr

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
