### PR TITLE
feat: add asciinema plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | argocd-image-updater           | [thatmlopsguy/asdf-argocd-image-updater](https://github.com/thatmlopsguy/asdf-argocd-image-updater)               |
 | aria2                          | [asdf-community/asdf-aria2](https://github.com/asdf-community/asdf-aria2)                                         |
 | asciidoctorj                   | [gliwka/asdf-asciidoctorj](https://github.com/gliwka/asdf-asciidoctorj)                                           |
+| asciinema                      | [ashikov/asdf-asciinema](https://github.com/ashikov/asdf-asciinema)                                               |
 | asdf-plugin-manager            | [asdf-community/asdf-plugin-manager](https://github.com/asdf-community/asdf-plugin-manager)                       |
 | assh                           | [zekker6/asdf-assh](https://github.com/zekker6/asdf-assh)                                                         |
 | atlas                          | [pbr0ck3r/asdf-atlas](https://github.com/pbr0ck3r/asdf-atlas)                                                     |

--- a/plugins/asciinema
+++ b/plugins/asciinema
@@ -1,0 +1,1 @@
+repository = https://github.com/ashikov/asdf-asciinema.git


### PR DESCRIPTION
## Summary

Description:

Adds the asciinema shortname for https://github.com/ashikov/asdf-asciinema so users can install the plugin without specifying its repository URL after this contribution is merged.

- Tool repo URL: https://github.com/asciinema/asciinema
- Plugin repo URL: https://github.com/ashikov/asdf-asciinema
- Tracking issue: https://github.com/ashikov/asdf-asciinema/issues/5

## Verification

- `scripts/test_plugin.bash --file plugins/asciinema` — passed
- `scripts/test_plugin.bash --diff origin/master HEAD` — passed
- `scripts/format.bash` — passed; no unrelated formatter changes
- `scripts/lint.bash` — passed with the repository-pinned Prettier, ShellCheck, and shfmt toolchain
- `git diff --check` — passed
- Plugin CI on the current default branch is green: https://github.com/ashikov/asdf-asciinema/actions/runs/32940917718

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/asciinema`
- [x] Your plugin CI tests are green
  - https://github.com/ashikov/asdf-asciinema/actions/runs/32940917718

<!-- Thank you for contributing to asdf-plugins! -->