### PR TITLE
feat: add agg plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ The `asdf` core provides a [security policy](https://github.com/asdf-vm/asdf/sec
 | actionlint                     | [crazy-matt/asdf-actionlint](https://github.com/crazy-matt/asdf-actionlint)                                       |
 | adr-tools                      | [td7x/asdf/adr-tools](https://gitlab.com/td7x/asdf/adr-tools)                                                     |
 | ag (the_silver_searcher)       | [koketani/asdf-ag](https://github.com/koketani/asdf-ag)                                                           |
+| agg                            | [ashikov/asdf-agg](https://github.com/ashikov/asdf-agg)                                                           |
 | age                            | [threkk/asdf-age](https://github.com/threkk/asdf-age)                                                             |
 | age-plugin-yubikey             | [str4d/asdf-age-plugin-yubikey](https://github.com/str4d/asdf-age-plugin-yubikey)                                 |
 | agebox                         | [slok/asdf-agebox](https://github.com/slok/asdf-agebox)                                                           |

--- a/plugins/agg
+++ b/plugins/agg
@@ -1,0 +1,1 @@
+repository = https://github.com/ashikov/asdf-agg.git


### PR DESCRIPTION
## Summary

Description: Add the `agg` plugin to the asdf shortname index.

- Tool repo URL: https://github.com/asciinema/agg
- Plugin repo URL: https://github.com/ashikov/asdf-agg
- Tracking issue: https://github.com/ashikov/asdf-agg/issues/4

Verification:

- `scripts/test_plugin.bash --file plugins/agg`
- `scripts/test_plugin.bash --diff upstream/master HEAD`
- `scripts/format.bash`
- `scripts/lint.bash`
- `git diff --check`

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/agg`
- [x] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->